### PR TITLE
Fix the entry point in setup.py (target review_install branch)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ setup(
     # entry point script
     entry_points={
         'console_scripts': [
-            'kalliope=kalliope:main',
+            'kalliope=kalliope.kalliope:main',
         ],
     },
 )


### PR DESCRIPTION
Hi,

This is a small PR for the review_install branch. I just fix the entry point config in the setup.py file because we must link to main function in `kalliope.py` now and not in `__init__.py` anymore.

Cheers