### PR TITLE
Default response when Order not found 

### DIFF
--- a/Docs/settings.md
+++ b/Docs/settings.md
@@ -201,10 +201,9 @@ Login used by the basic HTTP authentication. Must be provided if `password_prote
 Password used by the basic HTTP authentication. Must be provided if `password_protected` is `True`
 
 
-## Default response
+## Default synapse
 
-Ask Kalliope to run a defined synapse in case no order is found
-
+Run a default synapse when Kalliope can't find the order in any synapse.
 
 ```
 default_synapse: "synapse-name"

--- a/Docs/settings.md
+++ b/Docs/settings.md
@@ -111,7 +111,7 @@ E.g
 text_to_speech:
   - pico2wave:
       language: "fr-FR"
-  - voxygen:      
+  - voxygen:
       voice: "michel"
 ```
 
@@ -199,3 +199,18 @@ Login used by the basic HTTP authentication. Must be provided if `password_prote
 
 #### Password
 Password used by the basic HTTP authentication. Must be provided if `password_protected` is `True`
+
+
+## Default response
+
+Ask Kalliope to run a defined synapse in case no order is found
+
+
+```
+default_synapse: "synapse-name"
+```
+
+E.g
+```
+default_synapse: "Default-response"
+```

--- a/brain.yml
+++ b/brain.yml
@@ -1,5 +1,6 @@
 ---
   - includes:
+    - brains/default.yml
     - brains/ansible_playbook.yml
     - brains/gmail_checker.yml
     - brains/kill_switch.yml

--- a/brains/default.yml
+++ b/brains/default.yml
@@ -1,7 +1,7 @@
 ---
-  - name: "No-neuron-found"
+  - name: "Default-response"
     signals:
-      - order: "No-neuron-found"
+      - order: "Default-response"
     neurons:
       - say:
           message:

--- a/brains/default.yml
+++ b/brains/default.yml
@@ -1,0 +1,8 @@
+---
+  - name: "No-neuron-found"
+    signals:
+      - order: "No-neuron-found"
+    neurons:
+      - say:
+          message:
+            - "I didn't understand, Sir"

--- a/core/ConfigurationManager/SettingLoader.py
+++ b/core/ConfigurationManager/SettingLoader.py
@@ -101,6 +101,7 @@ class SettingLoader(object):
         random_wake_up_sounds = self._get_random_wake_up_sounds(settings)
         rest_api = self._get_rest_api(settings)
         cache_path = self._get_cache_path(settings)
+        default_synapse = self._get_default_synapse(settings)
 
         # Load the setting singleton with the parameters
         setting_object.default_tts_name = default_tts_name
@@ -113,6 +114,7 @@ class SettingLoader(object):
         setting_object.random_wake_up_sounds = random_wake_up_sounds
         setting_object.rest_api = rest_api
         setting_object.cache_path = cache_path
+        setting_object.default_synapse = default_synapse
 
         return setting_object
 
@@ -473,3 +475,32 @@ class SettingLoader(object):
             return cache_path
         else:
             raise SettingInvalidException("The cache_path seems to be invalid: %s" % cache_path)
+
+
+    @staticmethod
+    def _get_default_synapse(settings):
+        """
+        Return the name of the default synapse
+
+        :param settings: The YAML settings file
+        :type settings: dict
+        :return: the default synapse name
+        :rtype: String
+
+        :Example:
+
+            default_synapse = cls._get_default_synapse(settings)
+
+        .. seealso::
+        .. raises:: SettingNotFound, NullSettingException, SettingInvalidException
+        .. warnings:: Class Method and Private
+        """
+
+        try:
+            default_synapse = settings["default_synapse"]
+            logger.debug("Default synapse: %s" % default_synapse)
+        except KeyError, e:
+            default_synapse = None
+
+        return default_synapse
+

--- a/core/Models/Settings.py
+++ b/core/Models/Settings.py
@@ -18,6 +18,7 @@ class Settings(object):
                  triggers=None,
                  rest_api=None,
                  cache_path=None,
+                 default_synapse=None,
                  machine=None):
 
         self.default_tts_name = default_tts_name
@@ -30,6 +31,7 @@ class Settings(object):
         self.triggers = triggers
         self.rest_api = rest_api
         self.cache_path = cache_path
+        self.default_synapse = default_synapse
         self.machine = platform.machine()   # can be x86_64 or armv7l
 
     def __eq__(self, other):

--- a/core/OrderAnalyser.py
+++ b/core/OrderAnalyser.py
@@ -38,9 +38,6 @@ class OrderAnalyser:
         # create a dict of synapses that have been launched
         launched_synapses = self._get_matching_synapse_list(self.brain.synapses, self.order)
 
-        if not launched_synapses:
-            Utils.print_info("No synapse match the captured order: %s" % self.order)
-
         if not launched_synapses and self.main_controller.settings.default_synapse is not None:
             default_synapse = self._get_default_synapse(self.brain.synapses, self.main_controller.settings.default_synapse)
 
@@ -49,10 +46,13 @@ class OrderAnalyser:
                 Utils.print_info("Default synapse found: %s, running it" % default_synapse.name)
                 launched_synapses.append(default_synapse)
 
-        for synapse in launched_synapses:
-            params = self._get_synapse_params(synapse, self.order)
-            for neuron in synapse.neurons:
-                self._start_neuron(neuron, params)
+        if not launched_synapses:
+            Utils.print_info("No synapse match the captured order: %s" % self.order)
+        else:
+            for synapse in launched_synapses:
+                params = self._get_synapse_params(synapse, self.order)
+                for neuron in synapse.neurons:
+                    self._start_neuron(neuron, params)
 
         # return the list of launched synapse
         return launched_synapses

--- a/core/OrderAnalyser.py
+++ b/core/OrderAnalyser.py
@@ -40,11 +40,19 @@ class OrderAnalyser:
 
         if not launched_synapses:
             Utils.print_info("No synapse match the captured order: %s" % self.order)
-        else:
-            for synapse in launched_synapses:
-                params = self._get_synapse_params(synapse, self.order)
-                for neuron in synapse.neurons:
-                    self._start_neuron(neuron, params)
+
+        if not launched_synapses and self.main_controller.settings.default_synapse is not None:
+            default_synapse = self._get_default_synapse(self.brain.synapses, self.main_controller.settings.default_synapse)
+
+            if default_synapse is not None:
+                logger.debug("Default synapse found %s" % default_synapse)
+                Utils.print_info("Default synapse found: %s, running it" % default_synapse.name)
+                launched_synapses.append(default_synapse)
+
+        for synapse in launched_synapses:
+            params = self._get_synapse_params(synapse, self.order)
+            for neuron in synapse.neurons:
+                self._start_neuron(neuron, params)
 
         # return the list of launched synapse
         return launched_synapses
@@ -234,3 +242,22 @@ class OrderAnalyser:
             if n > c2[k]:
                 return False
         return True
+
+    @classmethod
+    def _get_default_synapse(cls, all_synapses_list, default_synapse_name):
+        """
+        Class method to get the default synapse if it exists.
+
+        :param all_synapses_list: the complete list of all synapses
+        :param default_synapse_name: the synapse to find
+        :return: the dict key/value
+        """
+        for synapse in all_synapses_list:
+            if synapse.name == default_synapse_name:
+                logger.debug("Default synapse found: %s" % synapse.name)
+                return synapse
+
+        logger.debug("Default synapse not found")
+        Utils.print_danger("Default synapse not found")
+        return None
+

--- a/settings.yml
+++ b/settings.yml
@@ -16,7 +16,7 @@ default_trigger: "snowboy"
 triggers:
   - snowboy:
       pmdl_file: "trigger/snowboy/resources/kalliope-FR-6samples.pmdl"
-      
+
 
 # ---------------------------
 # Speech to text
@@ -107,3 +107,6 @@ rest_api:
   password_protected: True
   login: admin
   password: secret
+
+# Specify an optional default synapse response in case your order is not found.
+default_synapse: "Default-response"


### PR DESCRIPTION
Attempt to implement issue #89 
This is the first part: Having the ability to set in settings.yml a default synapse response when Kalliope doesn't find one. 
This is an optional settings and not a mandatory one.

The second part would be a default synapse when recognition error (eg: Google Speech Recognition could not understand audio) but I've yet to find where to do it :).
