### PR TITLE
Rss reader neuron

### DIFF
--- a/Docs/neuron_list.md
+++ b/Docs/neuron_list.md
@@ -9,6 +9,7 @@ A neuron is a module that will perform some actions attached to an order. You ca
 | [kill_switch](../neurons/kill_switch/)             | Stop Kalliope process                                                                   |
 | [neurotransmitter](../neurons/neurotransmitter/)   | Link synapse together                                                                   |
 | [push_message](../neurons/push_message/)           | Send a push message to a remote device like Android/iOS/Windows Phone or Chrome browser |
+| [rss_reader](../neurons/rss_reader/)               | Get items from a RSS feed                                                               |
 | [say](../neurons/say/)                             | Make Kalliope talk by using TTS                                                         |
 | [script](../neurons/script/)                       | Run an executable script                                                                |
 | [shell](../neurons/shell/)                         | Run a shell command                                                                     |

--- a/install/files/python_requirements.txt
+++ b/install/files/python_requirements.txt
@@ -18,3 +18,4 @@ wikipedia==1.4.0
 requests==2.12.1
 httpretty==0.8.14
 mock==2.0.0
+feedparser==5.2.1

--- a/kalliope/brain.yml
+++ b/kalliope/brain.yml
@@ -5,6 +5,7 @@
     - brains/kill_switch.yml
     - brains/openweathermap.yml
     - brains/push_message.yml
+    - brains/rss_reader.yml
     - brains/say.yml
     - brains/script.yml
     - brains/shell.yml

--- a/kalliope/brains/rss_reader.yml
+++ b/kalliope/brains/rss_reader.yml
@@ -1,0 +1,19 @@
+---
+
+  - name: "news-theVerge"
+    signals:
+      - order: "What are the news from the verge ?"
+    neurons:
+      - rss_reader:
+          feed_url: "http://www.theverge.com/rss/index.xml"
+          file_template: templates/en_rss.j2
+          
+  - name: "news-sport"
+    signals:
+      - order: "What are the sport news ?"
+    neurons:
+      - rss_reader:
+          feed_url: "https://sports.yahoo.com/top/rss.xml"
+          max_items: 10
+          file_template: templates/en_rss.j2
+

--- a/kalliope/neurons/rss_reader/README.md
+++ b/kalliope/neurons/rss_reader/README.md
@@ -1,0 +1,59 @@
+# rss_reader
+
+## Synopsis
+
+This neuron access to a RSS feed and gives their items.
+
+## Options
+
+| parameter | required | default | choices | comment               |
+|-----------|----------|---------|---------|-----------------------|
+| feed_url  | YES      |         |         | Url of the feed.      |
+| max_items | NO       | 30      |         | Max items to returns. |
+
+## Return Values
+
+| Name     | Description                                                                            | Type    | sample                          |
+|----------|----------------------------------------------------------------------------------------|---------|---------------------------------|
+| feed     | Title of the feed                                                                      | string  | The Verge                       |
+| items    | A List with feed items (see [RSS spec](https://validator.w3.org/feed/docs/rss2.html))  | list    |                                 |
+
+## Synapses example
+
+Simple example. This is based on a file_template
+
+```
+  - name: "news-theVerge"
+    signals:
+      - order: "What are the news from the verge ?"
+    neurons:
+      - rss_reader:
+          feed_url: "http://www.theverge.com/rss/index.xml"
+          file_template: templates/en_rss.j2
+          
+```
+
+A example with max items set to 10. This is based on a file_template
+```
+  - name: "news-sport"
+    signals:
+      - order: "What are the sport news ?"
+    neurons:
+      - rss_reader:
+          feed_url: "https://sports.yahoo.com/top/rss.xml"
+          max_items: 10
+          file_template: templates/en_rss.j2    
+```
+
+Here the content of the `en_rss.j2`
+```
+Here's the news from {{ feed }}
+
+{% set count = 1 %}
+{% for item in items %}
+News {{ count }}. {{ item.title }}.
+{% set count = count + 1 %}
+{% endfor %}
+```
+## Notes
+

--- a/kalliope/neurons/rss_reader/__init__.py
+++ b/kalliope/neurons/rss_reader/__init__.py
@@ -1,0 +1,1 @@
+from rss_reader import Rss_reader

--- a/kalliope/neurons/rss_reader/rss_reader.py
+++ b/kalliope/neurons/rss_reader/rss_reader.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+import logging
+import feedparser
+
+from kalliope.core.NeuronModule import NeuronModule, MissingParameterException
+
+logging.basicConfig()
+logger = logging.getLogger("kalliope")
+
+
+class Rss_reader(NeuronModule):
+    def __init__(self, **kwargs):
+        super(Rss_reader, self).__init__(**kwargs)
+
+        self.feedUrl = kwargs.get('feed_url', None)
+        self.limit = kwargs.get('max_items', 30)
+
+        # check if parameters have been provided
+        if self._is_parameters_ok():
+
+            # prepare a returned dict
+            returned_dict = dict()
+
+            logging.debug("Reading feed from: %s" % self.feedUrl)
+
+            feed = feedparser.parse( self.feedUrl )
+
+            logging.debug("Read title from feed: %s" % feed["channel"]["title"])
+
+            returned_dict["feed"] = feed["channel"]["title"]
+            returned_dict["items"] = feed["items"][:self.limit]
+            
+            self.say(returned_dict)
+
+    def _is_parameters_ok(self):
+        """
+        Check if received parameters are ok to perform operations in the neuron
+        :return: true if parameters are ok, raise an exception otherwise
+
+        .. raises:: MissingParameterException
+        """
+        if self.feedUrl is None:
+            raise MissingParameterException("feed url parameter required")
+
+        return True

--- a/kalliope/neurons/rss_reader/tests/test_rss_reader.py
+++ b/kalliope/neurons/rss_reader/tests/test_rss_reader.py
@@ -1,0 +1,23 @@
+import unittest
+
+from kalliope.core.NeuronModule import MissingParameterException
+from kalliope.neurons.rss_reader.rss_reader import Rss_reader
+
+
+class TestRss_Reader(unittest.TestCase):
+
+    def setUp(self):
+        self.feedUrl="http://www.lemonde.fr/rss/une.xml"
+
+    def testParameters(self):
+        def run_test(parameters_to_test):
+            with self.assertRaises(MissingParameterException):
+                Rss_reader(**parameters_to_test)
+
+        # empty
+        parameters = dict()
+        run_test(parameters)
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/kalliope/templates/en_rss.j2
+++ b/kalliope/templates/en_rss.j2
@@ -1,0 +1,7 @@
+Here's the news from {{ feed }}
+
+{% set count = 1 %}
+{% for item in items %}
+News {{ count }}. {{ item.title }}.
+{% set count = count + 1 %}
+{% endfor %}

--- a/kalliope/templates/fr_rss.j2
+++ b/kalliope/templates/fr_rss.j2
@@ -1,0 +1,7 @@
+Voici les nouvelles de {{ feed }}
+
+{% set count = 1 %}
+{% for item in items %}
+Nouvelle {{ count }}. {{ item.title }}.
+{% set count = count + 1 %}
+{% endfor %}

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ setup(
         'requests==2.12.1',
         'httpretty==0.8.14',
         'mock==2.0.0',
+        'feedparser==5.2.1',
     ],
 
 


### PR DESCRIPTION
Add a rss reader neuron

Allow to get items from RSS feed.
There is an option to limit the number of items to return


NB: 
I rebase to last dev branch and I had to change import in Utils `__init__.py` to make it works 

`from kalliope.core.Utils.Utils import Utils`

instead of 

`from kalliope.core.Utils import Utils`

My knowlegde about python are very low 

 