### PR TITLE
Rewrite the install documentations to use setup.py and pip. #100 (target branch dev)

### DIFF
--- a/Docs/installation/debian_jessie.md
+++ b/Docs/installation/debian_jessie.md
@@ -1,45 +1,116 @@
 # Kalliope installation on Debian Jessie
 
-## Automated install
+## Requirements
 
-Clone the project
-```
-cd
-git clone https://github.com/kalliope-project/kalliope.git
-```
+### Debian packages requirements
 
-Edit `/etc/apt/sources.list` and check that your mirror accept "non-free" package
+Edit `/etc/apt/sources.list` and check that you have `contrib` and `non-free` and backports archives enabled:
 ```
-deb http://ftp.fr.debian.org/debian/ jessie main contrib non-free
-deb-src http://ftp.fr.debian.org/debian/ jessie main contrib non-free
+deb http://httpredir.debian.org/debian jessie main contrib non-free
+deb-src http://httpredir.debian.org/debian jessie main contrib non-free
+deb http://httpredir.debian.org/debian jessie-backports main contrib non-free
+deb-src http://httpredir.debian.org/debian jessie-backports main contrib non-free
 ```
 
-Run the install script.
-```
-./kalliope/install/install_kalliope.sh
-```
+Install some required system libraries and softwares:
 
-## Manual install
-
-To make Kalliope work, you will have to install a certain number of libraries:
 ```
 sudo apt-get update
 sudo apt-get install git python-pip python-dev libsmpeg0 libttspico-utils libsmpeg0 flac dialog libffi-dev libffi-dev libssl-dev portaudio19-dev build-essential libssl-dev libffi-dev sox libatlas3-base mplayer
 ```
 
-Clone the project
+You also need some packages from the backports:
+
+```
+sudo apt-get install -t jessie-backports python-setuptools
+sudo apt-get install -t jessie-backports python-pyasn1
+```
+
+## Installation
+
+### Method 1 - User install using the PIP package
+
+You can install kalliope on your system:
+```
+sudo pip install kalliope
+```
+
+Or just in your user home:
+```
+pip install --user kalliope
+```
+
+Run Kalliope from a shell:
+```
+kalliope start
+```
+
+### Method 2 - Manual user install using the git repository
+
+Clone the project:
 ```
 git clone https://github.com/kalliope-project/kalliope.git
 ```
 
-Install libs
+Install the project:
 ```
-sudo pip install -r install/files/python_requirements.txt
+sudo python setup.py install
+```
+
+Run Kalliope from a shell:
+```
+kalliope start
+```
+
+### Method 3 - Developer install using Virtualenv
+
+Install the `python-virtualenv` package:
+```
+sudo apt-get install python-virtualenv
+```
+
+Clone the project:
+```
+git clone https://github.com/kalliope-project/kalliope.git
+cd kalliope
+```
+
+Generate a local python environment:
+```
+virtualenv venv
+```
+
+Install the project using the local environment:
+```
+venv/bin/pip install --editable .
+```
+
+Run Kalliope from a shell:
+```
+venv/bin/kalliope start
+```
+
+### Method 4 - Developer, dependencies install only
+
+Clone the project:
+```
+git clone https://github.com/kalliope-project/kalliope.git
+cd kalliope
+```
+
+Install the python dependencies directly:
+```
+sudo pip install -r install/python_requirements.txt
+```
+
+Run Kalliope from a shell directly:
+```
+python kalliope.py start
 ```
 
 ## Test your env
 
-To ensure that you can record your voice, run the following command to capture audio input from your microphone
+To ensure that you can record your voice, run the following command to capture audio input from your microphone:
 ```
 rec test.wav
 ```

--- a/Docs/installation/raspbian_jessie.md
+++ b/Docs/installation/raspbian_jessie.md
@@ -1,34 +1,50 @@
 # Kalliope installation on Raspbian
 
-## Automated install
+## Requirements
 
-Clone the project
-```
-cd
-git clone https://github.com/kalliope-project/kalliope.git
-```
+### Debian packages requirements
 
-Run the install script.
-```
-./kalliope/install/install_kalliope.sh
-```
+Install some required system libraries and softwares:
 
-## Manual install
-
-To make Kalliope work, you will have to install a certain number of libraries:
 ```
 sudo apt-get update
 sudo apt-get install git python-pip python-dev libsmpeg0 libttspico-utils libsmpeg0 flac dialog libffi-dev libffi-dev libssl-dev portaudio19-dev build-essential libssl-dev libffi-dev sox libatlas3-base mplayer
 ```
 
-Clone the project
+## Installation
+
+### Method 1 - User install using the PIP package
+
+You can install kalliope on your system:
+```
+sudo pip install kalliope
+```
+
+Or just in your user home:
+```
+pip install --user kalliope
+```
+
+Run Kalliope:
+```
+kalliope start
+```
+
+### Method 2 - Manual user install using the git repository
+
+Clone the project:
 ```
 git clone https://github.com/kalliope-project/kalliope.git
 ```
 
-Install libs
+Install the project:
 ```
-sudo pip install -r install/files/python_requirements.txt
+sudo python setup.py install
+```
+
+Run Kalliope from a shell:
+```
+kalliope start
 ```
 
 # Raspberry Pi configuration

--- a/Docs/installation/ubuntu_16.04.md
+++ b/Docs/installation/ubuntu_16.04.md
@@ -1,39 +1,101 @@
 # Kalliope installation on Ubuntu 16.04
 
-## Automated install
+## Requirements
 
-Clone the project
-```
-cd
-git clone https://github.com/kalliope-project/kalliope.git
-```
+### Debian packages requirements
 
-Run the install script.
-```
-./kalliope/install/install_kalliope.sh
-```
+Install some required system libraries and softwares:
 
-## Manual install
-
-To make Kalliope work, you will have to install a certain number of libraries:
 ```
 sudo apt-get update
 sudo apt-get install git python-pip python-dev libsmpeg0 libttspico-utils libsmpeg0 flac dialog libffi-dev libffi-dev libssl-dev portaudio19-dev build-essential libssl-dev libffi-dev sox libatlas3-base mplayer
 ```
 
-Clone the project
+## Installation
+
+### Method 1 - User install using the PIP package
+
+You can install kalliope on your system:
+```
+sudo pip install kalliope
+```
+
+Or just in your user home:
+```
+pip install --user kalliope
+```
+
+Run Kalliope:
+```
+kalliope start
+```
+
+### Method 2 - Manual user install using the git repository
+
+Clone the project:
 ```
 git clone https://github.com/kalliope-project/kalliope.git
 ```
 
-Install libs
+Install the project:
 ```
-sudo pip install -r install/files/python_requirements.txt
+sudo python setup.py install
+```
+
+Run Kalliope from a shell:
+```
+kalliope start
+```
+
+### Method 3 - Developer install using Virtualenv
+
+Install the `python-virtualenv` package:
+```
+sudo apt-get install python-virtualenv
+```
+
+Clone the project:
+```
+git clone https://github.com/kalliope-project/kalliope.git
+cd kalliope
+```
+
+Generate a local python environment:
+```
+virtualenv venv
+```
+
+Install the project using the local environment:
+```
+venv/bin/pip install --editable .
+```
+
+Run Kalliope from a shell:
+```
+venv/bin/kalliope start
+```
+
+### Method 4 - Developer, dependencies install only
+
+Clone the project:
+```
+git clone https://github.com/kalliope-project/kalliope.git
+cd kalliope
+```
+
+Install the python dependencies directly:
+```
+sudo pip install -r install/python_requirements.txt
+```
+
+Run Kalliope from a shell directly:
+```
+python kalliope.py start
 ```
 
 ## Test your env
 
-To ensure that you can record your voice, run the following command to capture audio input from your microphone
+To ensure that you can record your voice, run the following command to capture audio input from your microphone:
 ```
 rec test.wav
 ```


### PR DESCRIPTION
I rewrote the 3 install procedures to use pip and setup.py like already discuss in #100 .

I test the new install procedures on Debian Jessie and Ubuntu 16.04 but not on Raspian Jessie because I don't have a Raspberry Pi available for testing now.

Cheers