### PR TITLE
fix community installation neuron

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+v0.4.2 / 2017-01-18
+===================
+- fix community neuron installation
+
 v0.4.1 / 2017-01-15
 ===================
 - add CORS support for REST API

--- a/kalliope/_version.py
+++ b/kalliope/_version.py
@@ -1,2 +1,2 @@
 # https://www.python.org/dev/peps/pep-0440/
-version_str = "0.4.1"
+version_str = "0.4.2"

--- a/kalliope/core/ResourcesManager.py
+++ b/kalliope/core/ResourcesManager.py
@@ -264,7 +264,7 @@ class ResourcesManager(object):
             current_version = match_current_version.group(0)
 
             for supported_version in supported_versions:
-                if version.parse(current_version) == version.parse(supported_version):
+                if version.parse(str(current_version)) == version.parse(str(supported_version)):
                     # we found the exact version
                     supported_version_found = True
                     break


### PR DESCRIPTION
in order to fix this when installing a neuron

```
Cloning repository...
Checking repository...
2017-01-18 08:20:56,420 :: DEBUG :: File path to load: /tmp/kalliope/resources/kalliope_new_module_temp_name/dna.yml 
2017-01-18 08:20:56,423 :: DEBUG :: [ResourcesManager] DNA file content: Dna: name: wikipedia_searcher, type: neuron, author: The dream team of Kalliope project, kalliope_supported_version: [0.4], tags: ['wikipedia', 'search engine', 'wiki']
2017-01-18 08:20:56,423 :: DEBUG :: [ResourcesManager] Current installed version of Kalliope: 0.4.1
2017-01-18 08:20:56,423 :: DEBUG :: [ResourcesManager] Module supported version: [0.4]
Traceback (most recent call last):
  File "/usr/local/bin/kalliope", line 11, in <module>
    load_entry_point('kalliope==0.4.1', 'console_scripts', 'kalliope')()
  File "/usr/local/lib/python2.7/dist-packages/kalliope-0.4.1-py2.7.egg/kalliope/__init__.py", line 105, in main
    res_manager.install()
  File "/usr/local/lib/python2.7/dist-packages/kalliope-0.4.1-py2.7.egg/kalliope/core/ResourcesManager.py", line 80, in install
    supported_versions=self.dna.kalliope_supported_version):
  File "/usr/local/lib/python2.7/dist-packages/kalliope-0.4.1-py2.7.egg/kalliope/core/ResourcesManager.py", line 267, in _check_supported_version
    if version.parse(current_version) == version.parse(supported_version):
  File "/usr/local/lib/python2.7/dist-packages/packaging/version.py", line 31, in parse
    return Version(version)
  File "/usr/local/lib/python2.7/dist-packages/packaging/version.py", line 200, in __init__
    match = self._regex.search(version)
TypeError: expected string or buffer
```