### PR TITLE
added option --run-order

### DIFF
--- a/Docs/kalliope_cli.md
+++ b/Docs/kalliope_cli.md
@@ -72,6 +72,15 @@ Example of use
 kalliope start --run-synapse "say-hello"
 ```
 
+### --run-order "Your Order"
+
+Run a specific order from command line.
+
+Example of use
+```bash
+kalliope start --run-order "hello"
+```
+
 ### --brain-file BRAIN_FILE
 
 Replace the default brain file from the root of the project folder by a custom one.

--- a/kalliope/__init__.py
+++ b/kalliope/__init__.py
@@ -23,9 +23,11 @@ logger = logging.getLogger("kalliope")
 
 def signal_handler(signal, frame):
     """
-    Used to catch a keyboard signal like Ctrl+C in order to kill the kalliope program
+    Used to catch a keyboard signal like Ctrl+C in order to kill the kalliope program.
+
     :param signal: signal handler
     :param frame: execution frame
+
     """
     print "\n"
     Utils.print_info("Ctrl+C pressed. Killing Kalliope")
@@ -36,18 +38,20 @@ ACTION_LIST = ["start", "gui", "install"]
 
 
 def main():
-    """
-    Entry point of Kalliope program
-    """
+    """Entry point of Kalliope program."""
+
     # create arguments
     parser = argparse.ArgumentParser(description='Kalliope')
     parser.add_argument("action", help="[start|gui|install]")
-    parser.add_argument("--run-synapse", help="Name of a synapse to load surrounded by quote")
-    parser.add_argument("--run-order", help="order surrounded by a quote")    
+    parser.add_argument("--run-synapse",
+                        help="Name of a synapse to load surrounded by quote")
+    parser.add_argument("--run-order", help="order surrounded by a quote")
     parser.add_argument("--brain-file", help="Full path of a brain file")
-    parser.add_argument("--debug", action='store_true', help="Show debug output")
+    parser.add_argument("--debug", action='store_true',
+                        help="Show debug output")
     parser.add_argument("--git-url", help="Git URL of the neuron to install")
-    parser.add_argument('-v', '--version', action='version', version='Kalliope ' + version_str)
+    parser.add_argument('-v', '--version', action='version',
+                        version='Kalliope ' + version_str)
 
     # parse arguments from script parameters
     args = parser.parse_args()
@@ -62,13 +66,14 @@ def main():
 
     logger.debug("kalliope args: %s" % args)
 
-    # by default, no brain file is set. Use the default one: brain.yml in the root path
+    # by default, no brain file is set.
+    # Use the default one: brain.yml in the root path
     brain_file = None
-    
+
     # check if user set a brain.yml file
     if args.brain_file:
         brain_file = args.brain_file
- 
+
     # check the user provide a valid action
     if args.action not in ACTION_LIST:
         Utils.print_warning("%s is not a recognised action\n" % args.action)
@@ -84,17 +89,18 @@ def main():
             }
             res_manager = ResourcesManager(**parameters)
             res_manager.install()
+        return
 
     # load the brain once
     brain_loader = BrainLoader(file_path=brain_file)
     brain = brain_loader.brain
 
     if args.action == "start":
-        
+
         # user set a synapse to start
         if args.run_synapse is not None:
             SynapseLauncher.start_synapse(args.run_synapse, brain=brain)
-            
+
         if args.run_order is not None:
             order_analyser = OrderAnalyser(args.run_order, brain=brain)
             order_analyser.start()
@@ -115,12 +121,12 @@ def main():
         ShellGui(brain=brain)
 
 
-
-
 def configure_logging(debug=None):
     """
-    Prepare log folder in current home directory
+    Prepare log folder in current home directory.
+
     :param debug: If true, set the lof level to debug
+
     """
     logger = logging.getLogger("kalliope")
     logger.propagate = False


### PR DESCRIPTION
added an option "--run-order" to directly run an order from command line.

Usage:
```bash
kalliope start --run-order "hello"
```

By the way a changed the order of processing the args in _init__.py
This way an "kalliope install" is possible without loading the brain file first. There is no need to have a brain file available for an install command.
This fixes the problem that if you delete and reinstall a neuron you must remove it from the brain.yml first. 