### PR TITLE
run default synapse when no order returned by STT

### DIFF
--- a/Docs/settings.md
+++ b/Docs/settings.md
@@ -259,7 +259,7 @@ Remember that an origin is composed of the scheme (http(s)), the port (eg: 80, 4
 
 ## Default synapse
 
-Run a default [synapse](brain.md) when Kalliope can't find the order in any synapse.
+Run a default [synapse](brain.md) when Kalliope can't find the order in any synapse or if the SST engine haven't understood the order.
 
 ```yml
 default_synapse: "synapse-name"

--- a/kalliope/brain.yml
+++ b/kalliope/brain.yml
@@ -14,3 +14,15 @@
       - say:
           message:
             - "Hello sir"
+
+  - name: "default-synapse"
+    signals:
+      - order: "default-synapse-order"
+    neurons:
+      - say:
+          message:
+            - "Je n'ai pas compris vôtre ordre"
+            - "Je ne connais pas cet ordre"
+            - "Veuillez renouveller votre ordre"
+            - "Veuillez reformuller s'il vous plait"
+            - "Je n'ai pas saisi cet ordre"

--- a/kalliope/core/MainController.py
+++ b/kalliope/core/MainController.py
@@ -3,6 +3,7 @@ import random
 from time import sleep
 
 from flask import Flask
+from kalliope.core.SynapseLauncher import SynapseLauncher
 from transitions import Machine
 
 from kalliope.core import Utils
@@ -189,12 +190,14 @@ class MainController:
     def analysing_order_thread(self):
         """
         Start the order analyser with the caught order to process
-        :param order: the text order to analyse
         """
         logger.debug("order in analysing_order_thread %s" % self.order_to_process)
         if self.order_to_process is not None:   # maybe we have received a null audio from STT engine
             order_analyser = OrderAnalyser(self.order_to_process, brain=self.brain)
             order_analyser.start()
+        else:
+            if self.settings.default_synapse is not None:
+                SynapseLauncher.start_synapse(name=self.settings.default_synapse, brain=self.brain)
         # return to the state "unpausing_trigger"
         self.unpause_trigger()
 

--- a/kalliope/settings.yml
+++ b/kalliope/settings.yml
@@ -137,7 +137,7 @@ rest_api:
 # Default Synapse
 # ---------------------------
 # Specify an optional default synapse response in case your order is not found.
-default_synapse: "Default-synapse"
+default_synapse: "default-synapse"
 
 # ---------------------------
 # Resource directory path

--- a/kalliope/settings.yml
+++ b/kalliope/settings.yml
@@ -126,7 +126,7 @@ on_ready_sounds:
 # Rest API
 # ---------------------------
 rest_api:
-  active: True
+  active: False
   port: 5000
   password_protected: True
   login: admin


### PR DESCRIPTION
- Run the default synapse if this one exist and if the STT engine doesn't return an order in order to Closes #196
- disable the rest api by default in settings for better performance on Rpi.