### PR TITLE
Update BrainLoader.py

### DIFF
--- a/kalliope/core/ConfigurationManager/BrainLoader.py
+++ b/kalliope/core/ConfigurationManager/BrainLoader.py
@@ -271,7 +271,7 @@ class BrainLoader(object):
             # print "parameter is string %s" % parameter
             if Utils.is_containing_bracket(parameter):
                 return cls._get_global_variable(sentence=parameter, settings=settings)
-            return parameter
+        return parameter
 
     @staticmethod
     def _get_global_variable(sentence, settings):


### PR DESCRIPTION
_replace_global_variables has to return unchanged parameter as last resort. Eg if parameter is an integer
For example, using the sentences=1 parameter in wiki_search neuron, parameter is set to None.