### PR TITLE
doc update, replace old syntax "args" by jinja input value

### DIFF
--- a/kalliope/neurons/ansible_playbook/README.md
+++ b/kalliope/neurons/ansible_playbook/README.md
@@ -28,7 +28,7 @@ CORE NEURON : No installation needed.
 ### Playbook without admin privileges
 
 Call the playbook named playbook.yml
-```
+```yml
   - name: "Ansible-test"
     signals:
       - order: "playbook"
@@ -40,8 +40,7 @@ Call the playbook named playbook.yml
 ```
 
 Content of the playbook. This playbook will use the [URI module](http://docs.ansible.com/ansible/uri_module.html) to interact with a webservice on a remote server.
-```
----
+```yml
 - name: Playbook
   hosts: localhost
   gather_facts: no
@@ -66,7 +65,7 @@ Content of the playbook. This playbook will use the [URI module](http://docs.ans
 
 In some cases, a playbook requires sudo right to perform admin operations like installing a package.
 In this case, you must give to the neuron the login and password of the user which has admin privileges.
-```
+```yml
   - name: "Ansible-root"
     signals:
       - order: "playbook"
@@ -79,7 +78,7 @@ In this case, you must give to the neuron the login and password of the user whi
 ```
 
 And the playbook would be. Notice that we use `become: True`
-```
+```yml
 - hosts: localhost
   gather_facts: no
   connection: local

--- a/kalliope/neurons/kill_switch/README.md
+++ b/kalliope/neurons/kill_switch/README.md
@@ -20,7 +20,7 @@ No returned values
 
 Simple example : 
 
-```
+```yml
   - name: "stop-kalliope"
     signals:
       - order: "goodbye"

--- a/kalliope/neurons/neurotransmitter/README.md
+++ b/kalliope/neurons/neurotransmitter/README.md
@@ -25,7 +25,7 @@ None
 ## Synapses example
 
 We call another synapse directly at the end of the first synapse
-```
+```yml
 - name: "direct-link"
     signals:
       - order: "direct link"
@@ -48,7 +48,7 @@ Here the synapse will ask the user if he likes french fries. If the user answer 
 If the user answer no, he will be redirected to another synapse that say something else.
 If the user say something that is not present in `answers`, he will be redirected to the synapse4.
 
-```
+```yml
  - name: "synapse1"
     signals:
       - order: "ask me a question"
@@ -92,8 +92,7 @@ If the user say something that is not present in `answers`, he will be redirecte
 Neurotransmitter also uses parameters in answers. You can provide parameters to your answers so they can be used by the synapse you are about to launch.
 /!\ The params defined in answers must match with the expected "args" params in the target synapse, otherwise an error is raised.
 
-```
-
+```yml
   - name: "synapse5"
     signals:
       - order: "give me the weather"
@@ -115,8 +114,7 @@ Neurotransmitter also uses parameters in answers. You can provide parameters to 
           lang: "fr"
           temp_unit: "celsius"
           country: "FR"
-          args:
-            - location
+          location: "{{ location }}"
           say_template:
           - "Today in {{ location }} the weather is {{ weather_today }} with {{ temp_today_temp }} celsius"
 ```

--- a/kalliope/neurons/say/README.md
+++ b/kalliope/neurons/say/README.md
@@ -22,7 +22,7 @@ No returned values
 
 Simple example : 
 
-```
+```yml
 - name: "Say-hello"
   signals:
     - order: "hello"
@@ -34,7 +34,7 @@ Simple example :
 
 With a multiple choice list, Kalliope will pick one randomly:
 
-```
+```yml
 - name: "Say-hello"
   signals:
     - order: "hello"
@@ -46,6 +46,16 @@ With a multiple choice list, Kalliope will pick one randomly:
           - "Good morning Sir"
 ```
 
+With an input value
+```yml
+- name: "Say-hello-to-friend"
+  signals:
+    - order: "say hello to {{ friend_name }}"
+  neurons:
+    - say:
+        message:
+          - "Hello {{ friend_name }}"     
+```
 
 ## Notes
 

--- a/kalliope/neurons/script/README.md
+++ b/kalliope/neurons/script/README.md
@@ -27,7 +27,7 @@ Values are only returned by the neuron if the async mode is set to `False`.
 ## Synapses example
 
 Simple example : 
-```
+```yml
   - name: "run-simple-script"
     signals:
       - order: "Run the script"
@@ -39,7 +39,7 @@ Simple example :
 If the script can take a long time and you don't want to block the Kalliope process, you can run it in asynchronous mode.
 Keep in mind that you cannot get any returned value with this mode.
 
-```
+```yml
   - name: "run-simple-script"
     signals:
       - order: "Run the script"
@@ -50,7 +50,7 @@ Keep in mind that you cannot get any returned value with this mode.
 ```
 
 Make Kalliope speak out loud the result of the script.
-```
+```yml
   - name: "run-script-an-give-output"
     signals:
       - order: "run the script"
@@ -58,6 +58,17 @@ Make Kalliope speak out loud the result of the script.
       - script:
           path: "/path/to/script.sh"   
           say_template: "{{ output }}"
+```
+
+Path an argument to the script from your order
+```yml
+  - name: "run-simple-script-with-input-value"
+    signals:
+      - order: "Run the script with {{ my_var }}"
+    neurons:
+      - script:
+          path: "/path/to/script.sh {{ my_var }}""   
+          async: True
 ```
 
 

--- a/kalliope/neurons/shell/README.md
+++ b/kalliope/neurons/shell/README.md
@@ -93,17 +93,15 @@ If you run it a second time, the command will fail as the file is not anymore pr
           file_template: remove_file.j2
 ```
 
-If you want to add argument to your shell command, you can use the query arguments.
+If you want to add argument to your shell command, you can use an input value from your order.
 ```
   - name: "Delete-a-specific-file"
     signals:
       - order: "remove file {{ query }}"
     neurons:
       - shell:
-          cmd: "rm "
-          file_template: remove_file.j2
-          args:
-              - query
+          cmd: "rm { query }}"
+          file_template: remove_file.j2          
 ```
 In the example above, kalliope will remove the file you asked for in the query.
 eg: "remove file test", the executed command will be "rm test"

--- a/kalliope/neurons/sleep/README.md
+++ b/kalliope/neurons/sleep/README.md
@@ -22,7 +22,7 @@ No returned values
 
 Simple example : 
 
-```
+```yml
   - name: "run-simple-sleep"
     signals:
       - order: "Wait for me "

--- a/kalliope/neurons/systemdate/README.md
+++ b/kalliope/neurons/systemdate/README.md
@@ -32,7 +32,7 @@ CORE NEURON : No installation needed.
 ## Synapses example
 
 Simple synapse that give the current time with only hours and minutes
-```
+```yml
 - name: "time"
   signals:
     - order: "what time is it"
@@ -43,7 +43,7 @@ Simple synapse that give the current time with only hours and minutes
 ```
 
 Synapse that give complete date and time with a template file.
-```
+```yml
 - name: "time"
   signals:
     - order: "what time is it"

--- a/kalliope/neurons/uri/README.md
+++ b/kalliope/neurons/uri/README.md
@@ -33,7 +33,7 @@ CORE NEURON : No installation needed.
 ## Synapses example
 
 Simple call to a server. The default method is GET
-```
+```yml
   - name: "test-get-url"
     signals:
       - order: "test-get-url"
@@ -43,7 +43,7 @@ Simple call to a server. The default method is GET
 ```
 
 A simple call with authentication
-```
+```yml
 - name: "test-get-url-with-auth"
     signals:
       - order: "test-get-url-with-auth"
@@ -55,7 +55,7 @@ A simple call with authentication
 ```
 
 A simple post with data inside the url 
-```
+```yml
 - name: "test-post-url-with-auth"
     signals:
       - order: "test-post-url-with-data"
@@ -66,7 +66,7 @@ A simple post with data inside the url
 ```
 
 A post with json data. Note that we need to escape quotes from the payload.
-```
+```yml
 - name: "test-post-url"
     signals:
       - order: "test-post-url"
@@ -80,7 +80,7 @@ A post with json data. Note that we need to escape quotes from the payload.
 ```
 
 A post with json data imported from a file and a custom header.
-```
+```yml
 - name: "test-post-url"
     signals:
       - order: "test-post-url"
@@ -100,7 +100,7 @@ And the `payload.json` would be (note that we don't need to escape any character
 ```
 
 A simple call to a deletion. Here we also ask Kalliope to tell use if request was a success through a template, depending on the returned status code.
-```
+```yml
   - name: "test-delete-url"
     signals:
       - order: "test-delete-url"
@@ -131,7 +131,7 @@ Here, we ask the server to return us the user with ID number 42. We know that th
 ```
 
 Here is the synapse we would use to make Kalliope speak out loud the name of the user and the name of his company
-```
+```yml
   - name: "test-get-url-with-template"
     signals:
       - order: "test-get-url-with-template"


### PR DESCRIPTION
We do not release a new version with this PR. It's only to fix the doc of our core neurons in the master branch which is inconsistent with the code of the 0.4.4.