### PR TITLE
add ‘keyword_entries’ to sphinx speech recognition

### DIFF
--- a/kalliope/stt/cmusphinx/cmusphinx.py
+++ b/kalliope/stt/cmusphinx/cmusphinx.py
@@ -18,6 +18,7 @@ class Cmusphinx(SpeechRecognition):
         # callback function to call after the translation speech/tex
         self.main_controller_callback = callback
         self.language = kwargs.get('language', "en-US")
+        self.keyword_entries = kwargs.get('keyword_entries', None)
 
         # start listening in the background
         self.set_callback(self.sphinx_callback)
@@ -29,7 +30,8 @@ class Cmusphinx(SpeechRecognition):
         called from the background thread
         """
         try:
-            captured_audio = recognizer.recognize_sphinx(audio, language=self.language)
+            captured_audio = recognizer.recognize_sphinx(audio, language=self.language,
+                                                         keyword_entries=self.keyword_entries)
             Utils.print_success("Sphinx Speech Recognition thinks you said %s" % captured_audio)
             self._analyse_audio(captured_audio)
 


### PR DESCRIPTION
Making use of `keyword_entries` allows to path a phrase dictionary to sphinx (full description [here](https://github.com/Uberi/speech_recognition/blob/master/reference/library-reference.rst#recognizer_instancerecognize_sphinxaudio_data-language--en-us-keyword_entries--none-show_all--false)). This makes sphinx much more reliable in the context of 
kalliope since the user can narrow down the grammar to the actual relevant phrases.
Keyword entries consist of a phrase and a sensitivity level ranging from 0 (insensitive; more false negatives) to 1 (very sensitive; more false positives).

```yaml
speech_to_text:
  - cmusphinx:
      language: "en-US"
      keyword_entries:
        - ["goodbye", 1]
        - ["hello world", 0.8]
```

