### PR TITLE
Add documentation for `keyword_entries` to cmusphinx/Readme

### DIFF
--- a/kalliope/stt/cmusphinx/README.md
+++ b/kalliope/stt/cmusphinx/README.md
@@ -20,6 +20,22 @@ Then, declare it as usual in your settings
 default_speech_to_text: "cmusphinx"
 
 speech_to_text:  
-  - cmusphinx
-    language: "en-US" #  [Installing other languages](https://github.com/Uberi/speech_recognition/blob/master/reference/pocketsphinx.rst#installing-other-languages)
+  - cmusphinx:
+      language: "en-US" #  [Installing other languages](https://github.com/Uberi/speech_recognition/blob/master/reference/pocketsphinx.rst#installing-other-languages)
+```
+
+#### Using keywords
+
+Sphinx usually operates in 'transcription mode' and will return whatever words it recognizes.
+Adding `keyword_entries` to the settings narrows down its search space and is more accurate than just looking for those same keywords in non-keyword-based transcriptions, because Sphinx knows specifically what sounds to look for.
+The parameter `keyword_entries` expects a list of tuples consisting of a phrase and a sensitivity level defining how sensitive to this phrase the recognizer should be, on a scale from 0 (very insensitive, more false negatives) to 1 (very sensitive, more false positives).
+```YAML
+default_speech_to_text: "cmusphinx"
+
+speech_to_text:  
+  - cmusphinx:
+      language: "en-US"
+      keyword_entries:
+        - ["hello", 0.8]
+        - ["stop the music", 0.6]
 ```


### PR DESCRIPTION
Added the feature documentation and also fixed the settings example for basic usage (wrong indent; lacking colon)