### PR TITLE
Fix #373: Configuration now checks for recognition_options 

### DIFF
--- a/kalliope/core/ConfigurationManager/SettingLoader.py
+++ b/kalliope/core/ConfigurationManager/SettingLoader.py
@@ -765,7 +765,7 @@ class SettingLoader(with_metaclass(Singleton, object)):
         """
         return RpiSettings object
         :param settings: The loaded YAML settings file
-        :return: 
+        :return:
         """
 
         try:
@@ -798,7 +798,7 @@ class SettingLoader(with_metaclass(Singleton, object)):
         recognition_options = RecognitionOptions()
 
         try:
-            recognition_options_dict = settings["RecognitionOptions"]
+            recognition_options_dict = settings["recognition_options"]
 
             if "energy_threshold" in recognition_options_dict:
                 recognition_options.energy_threshold = recognition_options_dict["energy_threshold"]


### PR DESCRIPTION
Configuration now checks for recognition_options in settings.yml instead of RecognitionOptions