### PR TITLE
Implements #376 : Start Kalliopé muted

### DIFF
--- a/Docs/kalliope_cli.md
+++ b/Docs/kalliope_cli.md
@@ -96,6 +96,20 @@ You can combine the options together like, for example:
 kalliope start --run-synapse "say-hello" --brain-file /home/me/my_other_brain.yml
 ```
 
+### --muted
+
+Starts Kalliope in a muted state.
+
+Example of use
+```bash
+kalliope start --muted
+```
+
+You can combine the options together like, for example:
+```bash
+kalliope start --muted --brain-file /home/me/my_other_brain.yml
+```
+
 ### --debug
 
 Show debug output in the console

--- a/Docs/settings.md
+++ b/Docs/settings.md
@@ -494,5 +494,14 @@ he LEDs will want to draw more, and if allowed to they will burn out the Raspber
 Therefore putting the resistors in the circuit will ensure that only this small current will flow and the Pi will not be damaged.
 
 
+## Start options
+Options that can be defined when kalliope starts.
+
+Example config
+```yaml
+start_options:
+  muted: True
+```
+
 ## Next: configure the brain of Kalliope
 Now your settings are ok, you can start creating the [brain](brain.md) of your assistant.

--- a/Tests/settings/settings_test.yml
+++ b/Tests/settings/settings_test.yml
@@ -134,3 +134,6 @@ resource_directory:
 # ---------------------------
 var_files:
   - "../Tests/settings/variables.yml"
+
+start_options:
+  muted: True

--- a/Tests/test_models.py
+++ b/Tests/test_models.py
@@ -264,7 +264,8 @@ class TestModels(unittest.TestCase):
                                 default_synapse="default_synapse",
                                 resources=None,
                                 variables={"key1": "val1"},
-                                recognition_options=recognition_options)
+                                recognition_options=recognition_options,
+                                start_options={'muted': False})
             setting1.kalliope_version = "0.4.5"
 
             setting2 = Settings(default_tts_name="accapela",
@@ -284,7 +285,8 @@ class TestModels(unittest.TestCase):
                                 default_synapse="my_default_synapse",
                                 resources=None,
                                 variables={"key1": "val1"},
-                                recognition_options=recognition_options)
+                                recognition_options=recognition_options,
+                                start_options={'muted': False})
             setting2.kalliope_version = "0.4.5"
 
             setting3 = Settings(default_tts_name="pico2wav",
@@ -305,7 +307,8 @@ class TestModels(unittest.TestCase):
                                 default_synapse="default_synapse",
                                 resources=None,
                                 variables={"key1": "val1"},
-                                recognition_options=recognition_options)
+                                recognition_options=recognition_options,
+                                start_options={'muted': False})
             setting3.kalliope_version = "0.4.5"
 
             expected_result_serialize = {
@@ -338,7 +341,8 @@ class TestModels(unittest.TestCase):
                 'triggers': ['snowboy'],
                 'rpi_settings': None,
                 'players': ['mplayer'],
-                'recognition_options': {'energy_threshold': 4000, 'adjust_for_ambient_noise_second': 0}
+                'recognition_options': {'energy_threshold': 4000, 'adjust_for_ambient_noise_second': 0},
+                'start_options': {'muted': False}
             }
 
             self.assertDictEqual(expected_result_serialize, setting1.serialize())

--- a/Tests/test_settings_loader.py
+++ b/Tests/test_settings_loader.py
@@ -56,7 +56,10 @@ class TestSettingLoader(unittest.TestCase):
                 {'pico2wave': {'cache': True, 'language': 'fr-FR'}},
                 {'voxygen': {'voice': 'Agnes', 'cache': True}}
             ],
-            'var_files': ["../Tests/settings/variables.yml"]
+            'var_files': ["../Tests/settings/variables.yml"],
+            'start_options': {
+                'muted': True
+            }
         }
 
         # Init the folders, otherwise it raises an exceptions
@@ -118,6 +121,9 @@ class TestSettingLoader(unittest.TestCase):
             "author": "Lamonf",
             "test_number": 60,
             "test": "kalliope"
+        }
+        settings_object.start_options = {
+            "muted": True
         }
         settings_object.machine = platform.machine()
         settings_object.recognition_options = RecognitionOptions()
@@ -219,6 +225,14 @@ class TestSettingLoader(unittest.TestCase):
         sl = SettingLoader(file_path=self.settings_file_to_test)
         self.assertEqual(expected_result,
                          sl._get_variables(self.settings_dict))
+
+    def test_get_start_options(self):
+        expected_result = {
+            "muted": True
+        }
+        sl = SettingLoader(file_path=self.settings_file_to_test)
+        self.assertEqual(expected_result,
+                         sl._get_start_options(self.settings_dict))
 
 
 if __name__ == '__main__':

--- a/kalliope/__init__.py
+++ b/kalliope/__init__.py
@@ -63,6 +63,7 @@ def parse_args(args):
     parser.add_argument("--tts-name", help="TTS name to uninstall")
     parser.add_argument("--trigger-name", help="Trigger name to uninstall")
     parser.add_argument("--signal-name", help="Signal name to uninstall")
+    parser.add_argument("--muted", action='store_true', help="Starts Kalliope muted")
     parser.add_argument('-v', '--version', action='version',
                         version='Kalliope ' + version_str)
 
@@ -155,6 +156,10 @@ def main():
                                                             is_api_call=False)
 
         if (parser.run_synapse is None) and (parser.run_order is None):
+            # if --muted
+            if parser.muted:
+                settings.start_options['muted'] = True
+
             # start rest api
             start_rest_api(settings, brain)
             start_kalliope(settings, brain)

--- a/kalliope/core/ConfigurationManager/SettingLoader.py
+++ b/kalliope/core/ConfigurationManager/SettingLoader.py
@@ -120,6 +120,7 @@ class SettingLoader(with_metaclass(Singleton, object)):
         variables = self._get_variables(settings)
         rpi_settings = self._get_rpi_settings(settings)
         recognition_options = self._get_recognition_options(settings)
+        start_options = self._get_start_options(settings)
 
         # Load the setting singleton with the parameters
         setting_object.default_tts_name = default_tts_name
@@ -142,6 +143,7 @@ class SettingLoader(with_metaclass(Singleton, object)):
         setting_object.variables = variables
         setting_object.rpi_settings = rpi_settings
         setting_object.recognition_options = recognition_options
+        setting_object.start_options = start_options
 
         return setting_object
 
@@ -814,3 +816,32 @@ class SettingLoader(with_metaclass(Singleton, object)):
 
         logger.debug("[SettingsLoader] recognition_options: %s" % str(recognition_options))
         return recognition_options
+
+    @staticmethod
+    def _get_start_options(settings):
+        """
+        Return the start options settings
+
+        :param settings: The YAML settings file
+        :type settings: dict
+        :return: A dict containing the start options
+        :rtype: dict
+        """
+        options = dict()
+        muted = False
+
+        try:
+            start_options = settings["start_options"]
+        except KeyError:
+            start_options = None
+
+        if start_options is not None:
+            try:
+                muted = start_options['muted']
+            except KeyError:
+                muted = False
+
+        options['muted'] = muted
+
+        logger.debug("Start options: %s" % options)
+        return options

--- a/kalliope/core/Models/Settings.py
+++ b/kalliope/core/Models/Settings.py
@@ -28,7 +28,8 @@ class Settings(object):
                  resources=None,
                  variables=None,
                  rpi_settings=None,
-                 recognition_options=None):
+                 recognition_options=None,
+                 start_options=None):
 
         self.default_tts_name = default_tts_name
         self.default_stt_name = default_stt_name
@@ -52,6 +53,7 @@ class Settings(object):
         self.kalliope_version = current_kalliope_version
         self.rpi_settings = rpi_settings
         self.recognition_options = recognition_options
+        self.start_options = start_options
 
     def serialize(self):
         """
@@ -84,6 +86,7 @@ class Settings(object):
             'kalliope_version': self.kalliope_version,
             'rpi_settings': self.rpi_settings.serialize() if self.rpi_settings is not None else None,
             'recognition_options': self.recognition_options.serialize() if self.recognition_options is not None else None,
+            'start_options': self.start_options,
         }
 
     def __str__(self):

--- a/kalliope/settings.yml
+++ b/kalliope/settings.yml
@@ -203,3 +203,9 @@ default_synapse: "default-synapse"
 #  pin_led_muted: 17
 #  pin_led_talking: 27
 #  pin_led_listening: 22
+
+# -------------
+# Start options
+# -------------
+#start_options:
+#  muted: False

--- a/kalliope/signals/order/order.py
+++ b/kalliope/signals/order/order.py
@@ -53,6 +53,11 @@ class Order(Thread):
         self.trigger_callback_called = False
         self.is_trigger_muted = False
 
+        # If kalliope is asked to start muted
+        #self.set_mute_status(self.settings.start_muted)
+        if self.settings.start_options['muted'] is True:
+            self.is_trigger_muted = True
+
         # save the current order listener
         self.order_listener = None
         self.order_listener_callback_called = False


### PR DESCRIPTION
[Implements #376]
This PR adds the ability to start Kalliopé muted, either
- by adding ```--muted``` when starting kalliope (eg: ```kalliope start --muted```)
- or by configuring it in the settings.yml like this:
```yaml
start_options:
  muted: True # default value is False
```

I decided to create a "start_options" dict instead of just a simple "start_muted: True/False" as I thought it might be useful later on but I can change this if needed.