### PR TITLE
[Refacto] Remove duplicate code for synapse launcher

### DIFF
--- a/Tests/test_hook_manager.py
+++ b/Tests/test_hook_manager.py
@@ -48,9 +48,9 @@ class TestInit(unittest.TestCase):
         """
         test with single synapse 
         """
-        with mock.patch("kalliope.core.SynapseLauncher.start_synapse_by_name") as mock_synapse_launcher:
+        with mock.patch("kalliope.core.SynapseLauncher.start_synapse_by_list_name") as mock_synapse_launcher:
             HookManager.on_waiting_for_trigger()
-            mock_synapse_launcher.assert_called_with("test", new_lifo=True)
+            mock_synapse_launcher.assert_called_with(["test"], new_lifo=True)
             mock_synapse_launcher.reset_mock()
 
     def test_on_triggered(self):

--- a/Tests/test_init.py
+++ b/Tests/test_init.py
@@ -59,7 +59,7 @@ class TestInit(unittest.TestCase):
 
         # test run_synapse
         sys.argv = ['kalliope.py', 'start', '--run-synapse', 'synapse_name']
-        with mock.patch('kalliope.core.SynapseLauncher.start_synapse_by_name') as mock_synapse_launcher:
+        with mock.patch('kalliope.core.SynapseLauncher.start_synapse_by_list_name') as mock_synapse_launcher:
             mock_synapse_launcher.return_value = None
             main()
             mock_synapse_launcher.assert_called()

--- a/Tests/test_synapse_launcher.py
+++ b/Tests/test_synapse_launcher.py
@@ -43,11 +43,11 @@ class TestSynapseLauncher(unittest.TestCase):
         Singleton._instances = dict()
         LifoManager.clean_saved_lifo()
 
-    def test_start_synapse_by_name(self):
+    def test_start_synapse_by_list_name_single_synapse(self):
         # existing synapse in the brain
         with mock.patch("kalliope.core.Lifo.LIFOBuffer.execute"):
             should_be_created_matched_synapse = MatchedSynapse(matched_synapse=self.synapse1)
-            SynapseLauncher.start_synapse_by_name("Synapse1", brain=self.brain_test)
+            SynapseLauncher.start_synapse_by_list_name(["Synapse1"], brain=self.brain_test)
             # we expect that the lifo has been loaded with the synapse to run
             expected_result = [[should_be_created_matched_synapse]]
             lifo_buffer = LifoManager.get_singleton_lifo()
@@ -60,8 +60,8 @@ class TestSynapseLauncher(unittest.TestCase):
             overriding_param = {
                 "val1": "val"
             }
-            SynapseLauncher.start_synapse_by_name("Synapse1", brain=self.brain_test,
-                                                  overriding_parameter_dict=overriding_param)
+            SynapseLauncher.start_synapse_by_list_name(["Synapse1"], brain=self.brain_test,
+                                                       overriding_parameter_dict=overriding_param)
             should_be_created_matched_synapse = MatchedSynapse(matched_synapse=self.synapse1,
                                                                overriding_parameter=overriding_param)
             # we expect that the lifo has been loaded with the synapse to run
@@ -70,7 +70,7 @@ class TestSynapseLauncher(unittest.TestCase):
 
         # non existing synapse in the brain
         with self.assertRaises(SynapseNameNotFound):
-            SynapseLauncher.start_synapse_by_name("not_existing", brain=self.brain_test)
+            SynapseLauncher.start_synapse_by_list_name(["not_existing"], brain=self.brain_test)
 
     def test_start_synapse_by_list_name(self):
         # test to start a list of synapse

--- a/kalliope/__init__.py
+++ b/kalliope/__init__.py
@@ -37,6 +37,7 @@ def signal_handler(signal, frame):
     Utils.print_info("Ctrl+C pressed. Killing Kalliope")
     sys.exit(0)
 
+
 # actions available
 ACTION_LIST = ["start", "gui", "install", "uninstall"]
 
@@ -114,7 +115,7 @@ def main():
         if not parser.neuron_name \
                 and not parser.stt_name \
                 and not parser.tts_name \
-                and not parser.trigger_name\
+                and not parser.trigger_name \
                 and not parser.signal_name:
             Utils.print_danger("You must specify a module name with "
                                "--neuron-name "
@@ -145,9 +146,8 @@ def main():
 
         # user set a synapse to start
         if parser.run_synapse is not None:
-            SynapseLauncher.start_synapse_by_name(parser.run_synapse,
-                                                  brain=brain)
-
+            SynapseLauncher.start_synapse_by_list_name([parser.run_synapse],
+                                                       brain=brain)
         if parser.run_order is not None:
             SynapseLauncher.run_matching_synapse_from_order(parser.run_order,
                                                             brain=brain,
@@ -175,6 +175,7 @@ class AppFilter(logging.Filter):
     """
     Class used to add a custom entry into the logger
     """
+
     def filter(self, record):
         record.app_version = "kalliope-%s" % version_str
         return True
@@ -191,10 +192,10 @@ def configure_logging(debug=None):
     logger.addFilter(AppFilter())
     logger.propagate = False
     syslog = logging.StreamHandler()
-    syslog .setLevel(logging.DEBUG)
+    syslog.setLevel(logging.DEBUG)
 
     formatter = logging.Formatter('%(asctime)s :: %(app_version)s :: %(message)s', "%Y-%m-%d %H:%M:%S")
-    syslog .setFormatter(formatter)
+    syslog.setFormatter(formatter)
 
     if debug:
         logger.setLevel(logging.DEBUG)
@@ -267,5 +268,3 @@ def start_kalliope(settings, brain):
 
     while True:  # keep main thread alive
         time.sleep(0.1)
-
-

--- a/kalliope/core/HookManager.py
+++ b/kalliope/core/HookManager.py
@@ -64,10 +64,6 @@ class HookManager(object):
         list_synapse = settings.hooks[hook_name]
         logger.debug("[HookManager] hook: %s , type: %s" % (hook_name, type(list_synapse)))
 
-        if isinstance(list_synapse, list):
-            return SynapseLauncher.start_synapse_by_list_name(list_synapse, new_lifo=True)
-
         if isinstance(list_synapse, str):
-            return SynapseLauncher.start_synapse_by_name(list_synapse, new_lifo=True)
-
-        return None
+            list_synapse = [list_synapse]
+        return SynapseLauncher.start_synapse_by_list_name(list_synapse, new_lifo=True)

--- a/kalliope/core/ShellGui.py
+++ b/kalliope/core/ShellGui.py
@@ -177,5 +177,5 @@ class ShellGui:
             self.show_main_menu()
         if code == self.d.OK:
             logger.debug("Run synapse from GUI: %s" % tag)
-            SynapseLauncher.start_synapse_by_name(tag, brain=self.brain)
+            SynapseLauncher.start_synapse_by_list_name([tag], brain=self.brain)
             self.show_synapses_test_menu()

--- a/kalliope/core/SynapseLauncher.py
+++ b/kalliope/core/SynapseLauncher.py
@@ -23,39 +23,6 @@ class SynapseNameNotFound(Exception):
 class SynapseLauncher(object):
 
     @classmethod
-    def start_synapse_by_name(cls, name, brain=None, overriding_parameter_dict=None, new_lifo=False):
-        """
-        Start a synapse by it's name
-        :param name: Name (Unique ID) of the synapse to launch
-        :param brain: Brain instance
-        :param overriding_parameter_dict: parameter to pass to neurons
-        :param new_lifo: If True, ask the HookManager to return a new lifo and not the singleton
-        """
-        logger.debug("[SynapseLauncher] start_synapse_by_name called with synapse name: %s " % name)
-
-        if brain is None:
-            brain = BrainLoader().brain
-
-        # check if we have found and launched the synapse
-        synapse = brain.get_synapse_by_name(synapse_name=name)
-
-        if not synapse:
-            raise SynapseNameNotFound("The synapse name \"%s\" does not exist in the brain file" % name)
-        else:
-            if new_lifo:
-                lifo_buffer = LifoManager.get_new_lifo()
-            else:
-                lifo_buffer = LifoManager.get_singleton_lifo()
-            list_synapse_to_process = list()
-            new_matching_synapse = MatchedSynapse(matched_synapse=synapse,
-                                                  matched_order=None,
-                                                  user_order=None,
-                                                  overriding_parameter=overriding_parameter_dict)
-            list_synapse_to_process.append(new_matching_synapse)
-            lifo_buffer.add_synapse_list_to_lifo(list_synapse_to_process)
-            return lifo_buffer.execute(is_api_call=True)
-
-    @classmethod
     def start_synapse_by_list_name(cls, list_name, brain=None, overriding_parameter_dict=None, new_lifo=False):
         """
         Start synapses by their name
@@ -74,6 +41,8 @@ class SynapseLauncher(object):
             list_synapse_object_to_start = list()
             for name in list_name:
                 synapse_to_start = brain.get_synapse_by_name(synapse_name=name)
+                if not synapse_to_start:
+                    raise SynapseNameNotFound("[SynapseLauncher] The synapse name \"%s\" does not exist in the brain file" % name)
                 list_synapse_object_to_start.append(synapse_to_start)
 
             # run the LIFO with all synapse

--- a/kalliope/signals/event/event.py
+++ b/kalliope/signals/event/event.py
@@ -51,7 +51,7 @@ class Event(SignalModule, Thread):
         # get a brain
         brain_loader = BrainLoader()
         brain = brain_loader.brain
-        SynapseLauncher.start_synapse_by_name(synapse_name, brain=brain)
+        SynapseLauncher.start_synapse_by_list_name([synapse_name], brain=brain)
 
     @staticmethod
     def get_parameter_from_dict(parameter_name, parameters_dict):

--- a/kalliope/signals/mqtt_subscriber/MqttClient.py
+++ b/kalliope/signals/mqtt_subscriber/MqttClient.py
@@ -110,9 +110,9 @@ class MqttClient(Thread):
             logger.debug("[MqttClient] start synapse name %s" % synapse.name)
             overriding_parameter_dict = dict()
             overriding_parameter_dict["mqtt_subscriber_message"] = message
-            SynapseLauncher.start_synapse_by_name(synapse.name,
-                                                  brain=self.brain,
-                                                  overriding_parameter_dict=overriding_parameter_dict)
+            SynapseLauncher.start_synapse_by_list_name([synapse.name],
+                                                       brain=self.brain,
+                                                       overriding_parameter_dict=overriding_parameter_dict)
 
     @staticmethod
     def _get_protocol(protocol):


### PR DESCRIPTION
Quick refactoring to remove some duplicate code from the synapse launcher.

Reuse the synapse_by_list_name method to run single synapse.