### PR TITLE
Add new on_order_completed hook

### DIFF
--- a/Docs/settings.md
+++ b/Docs/settings.md
@@ -245,6 +245,7 @@ List of available hook
 | on_stop_listening      | When the Speech to Text engine stop listening for an order      |
 | on_order_found         | When the pronounced order has been found in the brain           |
 | on_order_not_found     | When the pronounced order has not been found in the brain       |
+| on_processed_synapses  | When all neurons in synapses have been processed                |
 | on_mute                | When Kalliope switches from non muted to muted                  |
 | on_unmute              | When Kalliope switches from muted to non muted                  |
 | on_start_speaking      | When Kalliope starts speaking via the text to speech engine     |

--- a/Tests/settings/settings_test.yml
+++ b/Tests/settings/settings_test.yml
@@ -91,6 +91,7 @@ hooks:
   on_order_found:
   on_order_not_found:
     - "order-not-found-synapse"
+  on_processed_synapses:
   on_mute: []
   on_unmute: []
   on_start_speaking:

--- a/Tests/test_hook_manager.py
+++ b/Tests/test_hook_manager.py
@@ -74,6 +74,9 @@ class TestInit(unittest.TestCase):
             mock_synapse_launcher.assert_called_with(["order-not-found-synapse"], new_lifo=True)
             mock_synapse_launcher.reset_mock()
 
+    def test_on_processed_synapses(self):
+        self.assertIsNone(HookManager.on_processed_synapses())
+
     def test_on_mute(self):
         """
         test that empty list of synapse return none

--- a/Tests/test_settings_loader.py
+++ b/Tests/test_settings_loader.py
@@ -62,6 +62,7 @@ class TestSettingLoader(unittest.TestCase):
                       'on_mute': [],
                       'on_order_not_found': [
                           'order-not-found-synapse'],
+                      'on_processed_synapses': None,
                       'on_start_speaking': None,
                       'on_stop_speaking': None
                       }
@@ -137,6 +138,7 @@ class TestSettingLoader(unittest.TestCase):
                                  'on_mute': [],
                                  'on_order_not_found': [
                                      'order-not-found-synapse'],
+                                 'on_processed_synapses': None,
                                  'on_start_speaking': None,
                                  'on_stop_speaking': None,
                                  }

--- a/kalliope/core/HookManager.py
+++ b/kalliope/core/HookManager.py
@@ -36,6 +36,10 @@ class HookManager(object):
         return cls.execute_synapses_in_hook_name("on_order_not_found")
 
     @classmethod
+    def on_processed_synapses(cls):
+        return cls.execute_synapses_in_hook_name("on_processed_synapses")
+
+    @classmethod
     def on_mute(cls):
         return cls.execute_synapses_in_hook_name("on_mute")
 

--- a/kalliope/core/SynapseLauncher.py
+++ b/kalliope/core/SynapseLauncher.py
@@ -126,4 +126,6 @@ class SynapseLauncher(object):
             lifo_buffer.add_synapse_list_to_lifo(list_synapse_to_process)
             lifo_buffer.api_response.user_order = order_to_process
 
-            return lifo_buffer.execute(is_api_call=is_api_call, no_voice=no_voice)
+            execdata = lifo_buffer.execute(is_api_call=is_api_call, no_voice=no_voice)
+            HookManager.on_processed_synapses()
+            return execdata

--- a/kalliope/settings.yml
+++ b/kalliope/settings.yml
@@ -118,6 +118,7 @@ hooks:
   on_stop_listening:
   on_order_found:
   on_order_not_found: "order-not-found-synapse"
+  on_processed_synapses:
   on_mute:
   on_unmute:
   on_start_speaking:


### PR DESCRIPTION
This PR adds another Hook method to Kalliope: the `on_order_completed` hook. This hook is set to run after a synapse completes execution.

For my use-case, I've added it to perform cleanups to a ReSpeaker LED array (i.e. turn it off) after the synapse tasks are complete; I make use of `on_order_found` to turn on said LED array, so I needed a way to cleanly turn it off without cluttering up every one of my synapses (and adding unnecessary `sleep` calls everywhere).

The change is not very large: adding the class method for the hook, and then tying it in to the SynapseLauncher by splitting the return. I've added the new hook to the default `settings.yml` in this repo but it would also have to be updated everywhere for this to work (or I could add some 'ignore if not found' logic perhaps? Whichever you think is better!)