### PR TITLE
Rest Api Settings endpoints 

### DIFF
--- a/Docs/rest_api.md
+++ b/Docs/rest_api.md
@@ -36,7 +36,18 @@ Kalliope provides the REST API to manage the synapses. For configuring the API r
 | POST   | /settings/energy_threshold        | Update the energy_threshold value  |
 | GET    | /settings/ambient_noise_second    | Get the ambient_noise_second       |
 | POST   | /settings/ambient_noise_second    | Update the ambient_noise_second    |
-
+| GET    | /settings/hooks                   | Get the current hooks              |
+| POST   | /settings/hooks                   | Update the hooks list              |
+| GET    | /settings/variables               | Get the variables list             |
+| POST   | /settings/variables               | Update the variables list          |
+| GET    | /settings/default_tts             | Get current tts                    |
+| POST   | /settings/default_tts             | Update current tts                 |
+| GET    | /settings/default_stt             | Get current stt                    |
+| POST   | /settings/default_stt             | Update current stt                 |
+| GET    | /settings/default_player          | Get the current player             |
+| POST   | /settings/default_player          | Update current player              |
+| GET    | /settings/default_trigger         | Get the current trigger            |
+| POST   | /settings/default_trigger         | Update the current trigger         |
 
 
 ## Curl examples
@@ -318,7 +329,7 @@ If the order haven't match any synapses it will try to run the default synapse i
 ```
 
 Or return an empty list of matched synapse
-```
+```JSON
 {
   "matched_synapses": [],
   "status": null,
@@ -528,5 +539,97 @@ Output example:
 ```JSON
 {
   "energy_threshold": 4000
+}
+```
+
+
+## variables
+
+### Get variables list 
+
+Normal response codes: 200
+Error response codes : unauthorized(401), Bad request(400)
+
+
+Curl command:
+```bash
+curl -i --user admin:secret  -X GET  http://127.0.0.1:5000/settings/variables
+```
+
+Output example:
+```JSON
+{
+  "variables": {
+    "my_variable": "blabla", 
+    "nickname": "monf"
+  }
+}
+```
+
+### Update Variables
+
+Normal response codes: 200
+Error response codes : unauthorized(401), Bad request(400)
+
+
+Curl command:
+```bash
+curl -i -H "Content-Type: application/json" --user admin:secret  -X POST -d '{"mySecondVariable": "SecondValue", "Nickname2": "Nico"}' http://127.0.0.1:5000/settings/variables
+```
+
+Output example:
+```JSON
+{
+  "variables": {
+    "my_variable ": "blabla", 
+    "nickname": "monf",
+    "mysecondVariable": "SecondValue",
+    "Nickname2": "Nico"
+  }
+}
+```
+
+
+
+## default tts, stt, player, trigger
+
+### Get 
+
+Normal response codes: 200
+Error response codes : unauthorized(401), Bad request(400)
+
+
+Curl command:
+```bash
+curl -i --user admin:secret  -X GET  http://127.0.0.1:5000/settings/default_tts
+curl -i --user admin:secret  -X GET  http://127.0.0.1:5000/settings/default_stt
+curl -i --user admin:secret  -X GET  http://127.0.0.1:5000/settings/default_player
+curl -i --user admin:secret  -X GET  http://127.0.0.1:5000/settings/default_trigger
+```
+
+Output example:
+```JSON
+{
+  "default_tts": "pico2wave"
+}
+```
+
+
+### Update
+
+Normal response codes: 200
+Error response codes : unauthorized(401), Bad request(400)
+
+/!\ Note: To update a tts, stt, player, trigger it should be properly defined in the 'settings.yml' in the corresponding list.
+
+Curl command:
+```bash
+curl -i -H "Content-Type: application/json" --user admin:secret  -X POST -d '{"default_tts": "pico2wave"}' http://127.0.0.1:5000/settings/default_tts
+```
+
+Output example:
+```JSON
+{
+  "default_tts": "googletts"
 }
 ```

--- a/Docs/rest_api.md
+++ b/Docs/rest_api.md
@@ -3,22 +3,32 @@
 Kalliope provides the REST API to manage the synapses. For configuring the API refer to the [settings documentation](settings.md).
 
 - [Rest API](#rest-api)
-  - [Synapse API](#synapse-api)
-  - [Curl examples](#curl-examples)
-    - [Get Kalliope's version](#get-kalliopes-version)
+  - [API ref](#api-ref)
+  - [Get Kalliope's version](#get-kalliopes-version)
+  - [Synapses](#synapses)
     - [List synapses](#list-synapses)
     - [Show synapse details](#show-synapse-details)
     - [Run a synapse by its name](#run-a-synapse-by-its-name)
     - [Run a synapse from an order](#run-a-synapse-from-an-order)
     - [Run a synapse from an audio file](#run-a-synapse-from-an-audio-file)
-    - [The neurotransmitter case](#the-neurotransmitter-case)
+  - [The neurotransmitter case](#the-neurotransmitter-case)
+  - [Deaf](#deaf)
     - [Get deaf status](#get-deaf-status)
     - [Switch deaf status](#switch-deaf-status)
-  - [Mute flag](#mute-flag)
+  - [Mute](#mute)
     - [Get mute status](#get-mute-status)
     - [Set mute status](#set-mute-status)
+  - [energy_threshold](#energy-threshold)
+    - [Get energy_threshold status](#get-energy-threshold-status)
+    - [Set energy_threshold status](#set-energy-threshold-status)
+  - [Variables](#variables)
+    - [Get variables list](#get-variables-list)
+    - [Update Variables](#update-variables)
+  - [default tts, stt, player, trigger](#default-tts--stt--player--trigger)
+    - [Get](#get)
+    - [Update](#update)
 
-## Synapse API
+## API ref
 
 | Method | URL                               | Action                             |
 |--------|-----------------------------------|------------------------------------|
@@ -49,12 +59,9 @@ Kalliope provides the REST API to manage the synapses. For configuring the API r
 | GET    | /settings/default_trigger         | Get the current trigger            |
 | POST   | /settings/default_trigger         | Update the current trigger         |
 
-
-## Curl examples
-
 >**Note:** --user is only needed if `password_protected` is True
 
-### Get Kalliope's version
+## Get Kalliope's version
 
 Normal response codes: 200
 Error response codes: unauthorized(401)
@@ -68,6 +75,8 @@ Output example:
   "Kalliope version": "0.4.2"
 }
 ```
+
+## Synapses
 
 ### List synapses
 
@@ -343,7 +352,7 @@ Curl command:
 curl -i --user admin:secret -X POST http://localhost:5000/synapses/start/audio -F "file=@path/to/file.wav" -F mute="true"
 ```
 
-### The neurotransmitter case
+## The neurotransmitter case
 
 In case of leveraging the [neurotransmitter neuron](../kalliope/neurons/neurotransmitter), Kalliope expects back and forth answers.
 Fortunately, the API provides a way to continue interaction with Kalliope and still use neurotransmitter neurons while doing API calls.
@@ -425,6 +434,8 @@ curl -i --user admin:secret -H "Content-Type: application/json" -X POST -d '{"or
 
 And now the status is complete. This works also when you have nested neurotransmitter neurons, you just need to keep monitoring the status from the API answer.
 
+## Deaf
+
 ### Get deaf status
 
 Normal response codes: 200
@@ -461,7 +472,7 @@ Output example:
 }
 ```
 
-## Mute flag
+## Mute
 
 When you use the API, by default Kalliope will generate a text and process it into the TTS engine.
 Some calls to the API can be done with a flag that will tell Kalliope to only return the generated text without processing it into the audio player.
@@ -503,7 +514,8 @@ Output example:
 }
 ```
 
-## energy_threshold flag
+## energy_threshold
+
 Define the [energy_threshold](settings.md) in the settigns 
 
 ### Get energy_threshold status
@@ -543,7 +555,7 @@ Output example:
 ```
 
 
-## variables
+## Variables
 
 ### Get variables list 
 

--- a/Docs/rest_api.md
+++ b/Docs/rest_api.md
@@ -5,28 +5,30 @@ Kalliope provides the REST API to manage the synapses. For configuring the API r
 - [Rest API](#rest-api)
   - [API ref](#api-ref)
   - [Get Kalliope's version](#get-kalliopes-version)
-  - [Synapses](#synapses)
+  - [Brain](#brain)
     - [List synapses](#list-synapses)
     - [Show synapse details](#show-synapse-details)
     - [Run a synapse by its name](#run-a-synapse-by-its-name)
     - [Run a synapse from an order](#run-a-synapse-from-an-order)
     - [Run a synapse from an audio file](#run-a-synapse-from-an-audio-file)
   - [The neurotransmitter case](#the-neurotransmitter-case)
-  - [Deaf](#deaf)
-    - [Get deaf status](#get-deaf-status)
-    - [Switch deaf status](#switch-deaf-status)
-  - [Mute](#mute)
-    - [Get mute status](#get-mute-status)
-    - [Set mute status](#set-mute-status)
-  - [energy_threshold](#energy-threshold)
-    - [Get energy_threshold status](#get-energy-threshold-status)
-    - [Set energy_threshold status](#set-energy-threshold-status)
-  - [Variables](#variables)
-    - [Get variables list](#get-variables-list)
-    - [Update Variables](#update-variables)
-  - [default tts, stt, player, trigger](#default-tts--stt--player--trigger)
-    - [Get](#get)
-    - [Update](#update)
+  - [Settings](#settings)
+    - [Get current settings](#get-current-settings)
+    - [Deaf](#deaf)
+      - [Get deaf status](#get-deaf-status)
+      - [Switch deaf status](#switch-deaf-status)
+    - [Mute](#mute)
+      - [Get mute status](#get-mute-status)
+      - [Set mute status](#set-mute-status)
+    - [energy_threshold](#energy-threshold)
+      - [Get energy_threshold status](#get-energy-threshold-status)
+      - [Set energy_threshold status](#set-energy-threshold-status)
+    - [Variables](#variables)
+      - [Get variables list](#get-variables-list)
+      - [Update Variables](#update-variables)
+    - [default tts, stt, player, trigger](#default-tts--stt--player--trigger)
+      - [Get](#get)
+      - [Update](#update)
 
 ## API ref
 
@@ -76,7 +78,7 @@ Output example:
 }
 ```
 
-## Synapses
+## Brain
 
 ### List synapses
 
@@ -434,9 +436,176 @@ curl -i --user admin:secret -H "Content-Type: application/json" -X POST -d '{"or
 
 And now the status is complete. This works also when you have nested neurotransmitter neurons, you just need to keep monitoring the status from the API answer.
 
-## Deaf
+## Settings
 
-### Get deaf status
+### Get current settings
+
+Normal response codes: 200
+Error response codes: unauthorized(401), Bad request(400)
+
+Curl command:
+```bash
+curl -i --user admin:secret  -X GET  http://127.0.0.1:5000/settings
+```
+
+Output example:
+```JSON
+{
+  "settings": {
+    "cache_path": "/tmp/kalliope_tts_cache", 
+    "default_player_name": "mplayer", 
+    "default_stt_name": "google", 
+    "default_trigger_name": "snowboy", 
+    "default_tts_name": "pico2wave", 
+    "hooks": {
+      "on_deaf": null, 
+      "on_mute": null, 
+      "on_order_found": null, 
+      "on_order_not_found": "order-not-found-synapse", 
+      "on_processed_synapses": null, 
+      "on_start": "on-start-synapse", 
+      "on_start_listening": null, 
+      "on_start_speaking": null, 
+      "on_stop_listening": null, 
+      "on_stop_speaking": null, 
+      "on_stt_error": null, 
+      "on_triggered": "on-triggered-synapse", 
+      "on_undeaf": null, 
+      "on_unmute": null, 
+      "on_waiting_for_trigger": null
+    }, 
+    "kalliope_version": "0.5.1b", 
+    "machine": "x86_64", 
+    "options": {
+      "adjust_for_ambient_noise_second": 0, 
+      "deaf": false, 
+      "energy_threshold": 4000, 
+      "mute": false, 
+      "name": "Options", 
+      "stt_timeout": 0
+    }, 
+    "players": [
+      {
+        "name": "mplayer", 
+        "parameters": {}
+      }, 
+      {
+        "name": "pyalsaaudio", 
+        "parameters": {
+          "convert_to_wav": true, 
+          "device": "default"
+        }
+      }, 
+      {
+        "name": "pyaudioplayer", 
+        "parameters": {
+          "convert_to_wav": true
+        }
+      }, 
+      {
+        "name": "sounddeviceplayer", 
+        "parameters": {
+          "convert_to_wav": true
+        }
+      }
+    ], 
+    "resources": {
+      "neuron_folder": null, 
+      "signal_folder": null, 
+      "stt_folder": null, 
+      "trigger_folder": null, 
+      "tts_folder": null
+    }, 
+    "rest_api": {
+      "active": true, 
+      "allowed_cors_origin": false, 
+      "login": "admin", 
+      "password": "secret", 
+      "password_protected": true, 
+      "port": 5000
+    }, 
+    "stts": [
+      {
+        "name": "google", 
+        "parameters": {
+          "language": "fr-FR"
+        }
+      }, 
+      {
+        "name": "wit", 
+        "parameters": {
+          "key": "fakekey"
+        }
+      }, 
+      {
+        "name": "bing", 
+        "parameters": {
+          "key": "fakekey"
+        }
+      }, 
+      {
+        "name": "apiai", 
+        "parameters": {
+          "key": "fakekey", 
+          "language": "fr"
+        }
+      }, 
+      {
+        "name": "houndify", 
+        "parameters": {
+          "client_id": "fakeclientid", 
+          "key": "fakekey"
+        }
+      }
+    ], 
+    "triggers": [
+      {
+        "name": "snowboy", 
+        "parameters": {
+          "pmdl_file": "trigger/snowboy/resources/kalliope-FR-40samples.pmdl"
+        }
+      }
+    ], 
+    "ttss": [
+      {
+        "name": "pico2wave", 
+        "parameters": {
+          "cache": true, 
+          "language": "fr-FR"
+        }
+      }, 
+      {
+        "name": "googletts", 
+        "parameters": {
+          "cache": true, 
+          "language": "fr"
+        }
+      }, 
+      {
+        "name": "voicerss", 
+        "parameters": {
+          "cache": true, 
+          "key": "API_Key", 
+          "language": "fr-fr"
+        }
+      }, 
+      {
+        "name": "watson", 
+        "parameters": {
+          "password": "password", 
+          "username": "me", 
+          "voice": "fr-FR_ReneeVoice"
+        }
+      }
+    ], 
+    "variables": {}
+  }
+}
+```
+
+### Deaf
+
+#### Get deaf status
 
 Normal response codes: 200
 Error response codes: unauthorized(401), Bad request(400)
@@ -453,7 +622,7 @@ Output example:
 }
 ```
 
-### Switch deaf status
+#### Switch deaf status
 Kalliope can switch to 'deaf' mode, so she can not ear you anymore, the trigger/hotword is desactivated.
 However Kalliope continues to process synapses.
 
@@ -472,13 +641,13 @@ Output example:
 }
 ```
 
-## Mute
+### Mute
 
 When you use the API, by default Kalliope will generate a text and process it into the TTS engine.
 Some calls to the API can be done with a flag that will tell Kalliope to only return the generated text without processing it into the audio player.
 When `mute` is switched to true, Kalliope will not speak out loud on the server side.
 
-### Get mute status
+#### Get mute status
 
 Normal response codes: 200
 Error response codes : unauthorized(401), Bad request(400)
@@ -496,7 +665,7 @@ Output example:
 }
 ```
 
-### Set mute status
+#### Set mute status
 
 Normal response codes: 200
 Error response codes : unauthorized(401), Bad request(400)
@@ -514,11 +683,11 @@ Output example:
 }
 ```
 
-## energy_threshold
+### energy_threshold
 
 Define the [energy_threshold](settings.md) in the settigns 
 
-### Get energy_threshold status
+#### Get energy_threshold status
 
 Normal response codes: 200
 Error response codes : unauthorized(401), Bad request(400)
@@ -536,7 +705,7 @@ Output example:
 }
 ```
 
-### Set energy_threshold status
+#### Set energy_threshold status
 
 Normal response codes: 200
 Error response codes : unauthorized(401), Bad request(400)
@@ -555,9 +724,9 @@ Output example:
 ```
 
 
-## Variables
+### Variables
 
-### Get variables list 
+#### Get variables list 
 
 Normal response codes: 200
 Error response codes : unauthorized(401), Bad request(400)
@@ -578,7 +747,7 @@ Output example:
 }
 ```
 
-### Update Variables
+#### Update Variables
 
 Normal response codes: 200
 Error response codes : unauthorized(401), Bad request(400)
@@ -603,9 +772,9 @@ Output example:
 
 
 
-## default tts, stt, player, trigger
+### default tts, stt, player, trigger
 
-### Get 
+#### Get 
 
 Normal response codes: 200
 Error response codes : unauthorized(401), Bad request(400)
@@ -627,7 +796,7 @@ Output example:
 ```
 
 
-### Update
+#### Update
 
 Normal response codes: 200
 Error response codes : unauthorized(401), Bad request(400)

--- a/Docs/rest_api.md
+++ b/Docs/rest_api.md
@@ -28,10 +28,16 @@ Kalliope provides the REST API to manage the synapses. For configuring the API r
 | POST   | /synapses/start/id/<synapse_name> | Run a synapse by its name          |
 | POST   | /synapses/start/order             | Run a synapse from a text order    |
 | POST   | /synapses/start/audio             | Run a synapse from an audio sample |
-| GET    | /deaf                             | Get the current deaf status        |
-| POST   | /deaf                             | Switch the deaf status             |
-| GET    | /mute                             | Get the current mute status        |
-| POST   | /mute                             | Switch the mute status             |
+| GET    | /settings/deaf                    | Get the current deaf status        |
+| POST   | /settings/deaf                    | Switch the deaf status             |
+| GET    | /settings/mute                    | Get the current mute status        |
+| POST   | /settings/mute                    | Switch the mute status             |
+| GET    | /settings/energy_threshold        | Get the current energy_threshold   |
+| POST   | /settings/energy_threshold        | Update the energy_threshold value  |
+| GET    | /settings/ambient_noise_second    | Get the ambient_noise_second       |
+| POST   | /settings/ambient_noise_second    | Update the ambient_noise_second    |
+
+
 
 ## Curl examples
 
@@ -483,5 +489,44 @@ Output example:
 ```JSON
 {
   "mute": true
+}
+```
+
+## energy_threshold flag
+Define the [energy_threshold](settings.md) in the settigns 
+
+### Get energy_threshold status
+
+Normal response codes: 200
+Error response codes : unauthorized(401), Bad request(400)
+
+
+Curl command:
+```bash
+curl -i --user admin:secret  -X GET  http://127.0.0.1:5000/settings/energy_threshold
+```
+
+Output example:
+```JSON
+{
+  "energy_threshold": 4000
+}
+```
+
+### Set energy_threshold status
+
+Normal response codes: 200
+Error response codes : unauthorized(401), Bad request(400)
+
+
+Curl command:
+```bash
+curl -i -H "Content-Type: application/json" --user admin:secret  -X POST -d '{"energy_threshold": 4000}' http://127.0.0.1:5000/settings/energy_threshold
+```
+
+Output example:
+```JSON
+{
+  "energy_threshold": 4000
 }
 ```

--- a/Tests/settings/settings_test.yml
+++ b/Tests/settings/settings_test.yml
@@ -42,8 +42,8 @@ text_to_speech:
   - pico2wave:
       language: "fr-FR"
       cache: True
-  - voxygen:
-      voice: "Agnes"
+  - googletts:
+      language: "fr"
       cache: True
 
 # ---------------------------

--- a/Tests/test_models.py
+++ b/Tests/test_models.py
@@ -2,6 +2,7 @@ import unittest
 import ast
 import mock
 
+from kalliope.core.Models.settings.Options import Options
 from kalliope.core.Models.settings.Player import Player
 from kalliope.core.Models.Signal import Signal
 from kalliope.core.Models.settings.Tts import Tts
@@ -243,76 +244,60 @@ class TestModels(unittest.TestCase):
                                 active=True,
                                 port=5000, allowed_cors_origin="*")
 
+            tts1 = Tts(name="tts1", parameters=dict())
+            tts2 = Tts(name="tts2", parameters=dict())
+            stt1 = Stt(name="stt1", parameters=dict())
+            stt2 = Stt(name="stt2", parameters=dict())
+            trigger1 = Trigger(name="snowboy", parameters=dict())
+            player = Player(name="player1")
+            resources = Resources()
+            options = Options()
+
             setting1 = Settings(default_tts_name="pico2wav",
                                 default_stt_name="google",
                                 default_trigger_name="swoyboy",
                                 default_player_name="mplayer",
-                                ttss=["ttts"],
-                                stts=["stts"],
-                                triggers=["snowboy"],
-                                players=["mplayer"],
+                                ttss=[tts1],
+                                stts=[stt1],
+                                triggers=[trigger1],
+                                players=[player],
                                 rest_api=rest_api1,
                                 cache_path="/tmp/kalliope",
-                                resources=None,
+                                resources=resources,
                                 variables={"key1": "val1"},
-                                options={'deaf': False, 'mute': False})
+                                options=options)
             setting1.kalliope_version = "0.4.5"
 
-            setting2 = Settings(default_tts_name="accapela",
-                                default_stt_name="bing",
+            setting2 = Settings(default_tts_name="pico2wav",
+                                default_stt_name="google",
                                 default_trigger_name="swoyboy",
                                 default_player_name="mplayer",
-                                ttss=["ttts"],
-                                stts=["stts"],
-                                triggers=["snowboy"],
+                                ttss=[tts2],
+                                stts=[stt2],
+                                triggers=[trigger1],
+                                players=[player],
                                 rest_api=rest_api1,
-                                cache_path="/tmp/kalliope_tmp",
-                                resources=None,
+                                cache_path="/tmp/kalliope",
+                                resources=resources,
                                 variables={"key1": "val1"},
-                                options={'deaf': False, 'mute': False})
-            setting2.kalliope_version = "0.4.5"
+                                options=options)
 
             setting3 = Settings(default_tts_name="pico2wav",
                                 default_stt_name="google",
                                 default_trigger_name="swoyboy",
                                 default_player_name="mplayer",
-                                ttss=["ttts"],
-                                stts=["stts"],
-                                triggers=["snowboy"],
-                                players=["mplayer"],
+                                ttss=[tts1],
+                                stts=[stt1],
+                                triggers=[trigger1],
+                                players=[player],
                                 rest_api=rest_api1,
                                 cache_path="/tmp/kalliope",
-                                resources=None,
+                                resources=resources,
                                 variables={"key1": "val1"},
-                                options={'deaf': False, 'mute': False})
+                                options=options)
             setting3.kalliope_version = "0.4.5"
 
-            expected_result_serialize = {
-                'default_tts_name': 'pico2wav',
-                'hooks': None,
-                'rest_api':
-                    {
-                        'password_protected': True,
-                        'port': 5000,
-                        'active': True,
-                        'allowed_cors_origin': '*',
-                        'password': 'password',
-                        'login': 'admin'
-                    },
-                'default_stt_name': 'google',
-                'kalliope_version': '0.4.5',
-                'default_trigger_name': 'swoyboy',
-                'default_player_name': 'mplayer',
-                'cache_path': '/tmp/kalliope',
-                'stts': ['stts'],
-                'machine': 'pumpkins',
-                'ttss': ['ttts'],
-                'variables': {'key1': 'val1'},
-                'resources': None,
-                'triggers': ['snowboy'],
-                'players': ['mplayer'],
-                'options': {'deaf': False, 'mute': False}
-            }
+            expected_result_serialize = {'default_tts_name': 'pico2wav', 'default_stt_name': 'google', 'default_trigger_name': 'swoyboy', 'default_player_name': 'mplayer', 'ttss': [{'name': 'tts1', 'parameters': {}}], 'stts': [{'name': 'stt1', 'parameters': {}}], 'triggers': [{'name': 'snowboy', 'parameters': {}}], 'players': [{'name': 'player1', 'parameters': None}], 'rest_api': {'password_protected': True, 'login': 'admin', 'password': 'password', 'active': True, 'port': 5000, 'allowed_cors_origin': '*'}, 'cache_path': '/tmp/kalliope', 'resources': {'neuron_folder': None, 'stt_folder': None, 'tts_folder': None, 'trigger_folder': None, 'signal_folder': None}, 'variables': {'key1': 'val1'}, 'machine': 'pumpkins', 'kalliope_version': '0.4.5', 'options': {'name': 'Options', 'energy_threshold': 4000, 'adjust_for_ambient_noise_second': 0, 'deaf': None, 'mute': None, 'stt_timeout': 0}, 'hooks': None}
 
             self.maxDiff = None
             self.assertDictEqual(expected_result_serialize, setting1.serialize())

--- a/Tests/test_setting_editor.py
+++ b/Tests/test_setting_editor.py
@@ -17,6 +17,7 @@ class TestSettingEditor(unittest.TestCase):
     """
     Test class for the ~SettingEditor class and methods
     """
+
     def setUp(self):
         # get current script directory path. We are in /an/unknown/path/kalliope/core/tests
         cur_script_directory = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
@@ -66,7 +67,10 @@ class TestSettingEditor(unittest.TestCase):
         with mock.patch("kalliope.core.ConfigurationManager.SettingLoader") as mock_setting_loader:
             mock_setting_loader.return_value(self.sl)
             SettingEditor.set_default_player(default_name)
-            self.assertEqual(default_name, self.sl.settings.default_player_name)
+            self.assertEqual("mplayer", self.sl.settings.default_player_name)  # not existing in the list, not updated !
+            default_name = "pyalsaaudio"
+            SettingEditor.set_default_player(default_name)
+            self.assertEqual(default_name, self.sl.settings.default_player_name)  # Updated
 
     def test_set_players(self):
         new_player = Player(name="totoplayer", parameters={})
@@ -79,6 +83,10 @@ class TestSettingEditor(unittest.TestCase):
         default_name = "NameTrigger"
         with mock.patch("kalliope.core.ConfigurationManager.SettingLoader") as mock_setting_loader:
             mock_setting_loader.return_value(self.sl)
+            SettingEditor.set_default_trigger(default_name)
+            self.assertEqual("snowboy",
+                             self.sl.settings.default_trigger_name)  # not existing in the list, not updated !
+            default_name = "snowboy"
             SettingEditor.set_default_trigger(default_name)
             self.assertEqual(default_name, self.sl.settings.default_trigger_name)
 
@@ -94,7 +102,10 @@ class TestSettingEditor(unittest.TestCase):
         with mock.patch("kalliope.core.ConfigurationManager.SettingLoader") as mock_setting_loader:
             mock_setting_loader.return_value(self.sl)
             SettingEditor.set_default_stt(default_name)
-            self.assertEqual(default_name, self.sl.settings.default_stt_name)
+            self.assertEqual("google", self.sl.settings.default_stt_name) # not updated because not in the list
+            default_name = "google"
+            SettingEditor.set_default_stt(default_name)
+            self.assertEqual(default_name, self.sl.settings.default_stt_name) # updated
 
     def test_set_stts(self):
         new_stt = Stt(name="totoStt", parameters={})
@@ -107,6 +118,9 @@ class TestSettingEditor(unittest.TestCase):
         default_name = "NameTts"
         with mock.patch("kalliope.core.ConfigurationManager.SettingLoader") as mock_setting_loader:
             mock_setting_loader.return_value(self.sl)
+            SettingEditor.set_default_tts(default_name)
+            self.assertEqual("pico2wave", self.sl.settings.default_tts_name)
+            default_name = "voxygen"
             SettingEditor.set_default_tts(default_name)
             self.assertEqual(default_name, self.sl.settings.default_tts_name)
 

--- a/Tests/test_setting_editor.py
+++ b/Tests/test_setting_editor.py
@@ -120,7 +120,7 @@ class TestSettingEditor(unittest.TestCase):
             mock_setting_loader.return_value(self.sl)
             SettingEditor.set_default_tts(default_name)
             self.assertEqual("pico2wave", self.sl.settings.default_tts_name)
-            default_name = "voxygen"
+            default_name = "googletts"
             SettingEditor.set_default_tts(default_name)
             self.assertEqual(default_name, self.sl.settings.default_tts_name)
 

--- a/Tests/test_settings_loader.py
+++ b/Tests/test_settings_loader.py
@@ -24,7 +24,10 @@ class TestSettingLoader(unittest.TestCase):
         # get parent dir. Now we are in /an/unknown/path/kalliope
         root_dir = os.path.normpath(cur_script_directory + os.sep + os.pardir)
 
-        self.settings_file_to_test = root_dir + os.sep + "Tests/settings/settings_test.yml"
+        if "/Tests" in os.getcwd():
+            self.settings_file_to_test = root_dir + os.sep + "settings/settings_test.yml"
+        else:
+            self.settings_file_to_test = root_dir + os.sep + "Tests/settings/settings_test.yml"
 
         self.settings_dict = {
             'rest_api':

--- a/Tests/test_settings_loader.py
+++ b/Tests/test_settings_loader.py
@@ -48,7 +48,7 @@ class TestSettingLoader(unittest.TestCase):
             'default_speech_to_text': 'google',
             'text_to_speech': [
                 {'pico2wave': {'cache': True, 'language': 'fr-FR'}},
-                {'voxygen': {'voice': 'Agnes', 'cache': True}}
+                {'googletts': {'language': 'fr', 'cache': True}}
                 ],
             'var_files': ["../Tests/settings/variables.yml"],
             'options': {'energy_threshold': 3000, 'deaf': True, 'mute': False},
@@ -101,7 +101,7 @@ class TestSettingLoader(unittest.TestCase):
         settings_object.default_trigger_name = "snowboy"
         settings_object.default_player_name = "mplayer"
         tts1 = Tts(name="pico2wave", parameters={'cache': True, 'language': 'fr-FR'})
-        tts2 = Tts(name="voxygen", parameters={'voice': 'Agnes', 'cache': True})
+        tts2 = Tts(name="googletts", parameters={'language': 'fr', 'cache': True})
         settings_object.ttss = [tts1, tts2]
         stt = Stt(name="google", parameters={'language': 'fr-FR'})
         settings_object.stts = [stt]
@@ -171,7 +171,7 @@ class TestSettingLoader(unittest.TestCase):
 
     def test_get_ttss(self):
         tts1 = Tts(name="pico2wave", parameters={'cache': True, 'language': 'fr-FR'})
-        tts2 = Tts(name="voxygen", parameters={'voice': 'Agnes', 'cache': True})
+        tts2 = Tts(name="googletts", parameters={'language': 'fr', 'cache': True})
         sl = SettingLoader(file_path=self.settings_file_to_test)
         self.assertEqual([tts1, tts2], sl._get_ttss(self.settings_dict))
 

--- a/kalliope/core/ConfigurationManager/SettingEditor.py
+++ b/kalliope/core/ConfigurationManager/SettingEditor.py
@@ -11,6 +11,20 @@ logger = logging.getLogger("kalliope")
 class SettingEditor(object):
     """This Static class provides methods/functions to update properties from the Settings"""
 
+    @staticmethod
+    def _check_name_in_list_settings_entry(name_to_check, list_settings_entry):
+        """
+        manage object models : STT, TRIGGERS, TTS, PLAYERS because they have "name" attributes
+        :param name_to_check: name to find in the list_settings_entry ~kalliope.core.Models.settings.SettingsEntry.SettingsEntry
+        :param list_settings_entry: the list of SettingsEntry to inspect
+        :return: True if the name_to_check corresponds to a name in the SettingsEntry list provided.
+        """
+        found = False
+        for settings_entry in list_settings_entry:
+            if settings_entry.name == name_to_check:
+                found = True
+        return found
+
     # Options
     @staticmethod
     def set_mute_status(mute=False):
@@ -70,14 +84,17 @@ class SettingEditor(object):
             settings.options.energy_threshold = energy_threshold
 
     # Players
-    @staticmethod
-    def set_default_player(default_player_name):
+    @classmethod
+    def set_default_player(cls, default_player_name):
         """
         Set dynamically a new default_player in the settings
         :param default_player_name: string value
         """
         settings = SettingLoader().settings
-        settings.default_player_name = default_player_name
+        if cls._check_name_in_list_settings_entry(default_player_name, settings.players):
+            settings.default_player_name = default_player_name
+        else:
+            logger.debug("[Settings] default_player %s is not defined in settings file ", default_player_name)
 
     @staticmethod
     def set_players(new_player):
@@ -92,14 +109,18 @@ class SettingEditor(object):
         settings.players = list_no_duplicate_player
 
     # TTS
-    @staticmethod
-    def set_default_tts(default_tts_name):
+    @classmethod
+    def set_default_tts(cls, default_tts_name):
         """
         Set dynamically a new default_tts_name in the settings
         :param default_tts_name: string value
         """
         settings = SettingLoader().settings
-        settings.default_tts_name = default_tts_name
+        # Verify that the default name exists in the settings list
+        if cls._check_name_in_list_settings_entry(default_tts_name, settings.ttss):
+            settings.default_tts_name = default_tts_name
+        else:
+            logger.debug("[SettingsEditor] default_tts %s is not defined in settings file ", default_tts_name)
 
     @staticmethod
     def set_ttss(new_tts):
@@ -114,14 +135,17 @@ class SettingEditor(object):
         settings.ttss = list_no_duplicate_tts
 
     # STT
-    @staticmethod
-    def set_default_stt(default_stt_name):
+    @classmethod
+    def set_default_stt(cls, default_stt_name):
         """
-        Set dynamically a new default_stt_name in the settings
+        Set dynamically a new default_stt_name in the settings if in the list of stts.
         :param default_stt_name: string value
         """
         settings = SettingLoader().settings
-        settings.default_stt_name = default_stt_name
+        if cls._check_name_in_list_settings_entry(default_stt_name, settings.stts):
+            settings.default_stt_name = default_stt_name
+        else:
+            logger.debug("[Settings] default_stt %s is not defined in settings file ", default_stt_name)
 
     @staticmethod
     def set_stts(new_stt):
@@ -135,14 +159,17 @@ class SettingEditor(object):
         settings.stts = list_no_duplicate_stt
 
     # TRIGGER
-    @staticmethod
-    def set_default_trigger(default_trigger):
+    @classmethod
+    def set_default_trigger(cls, default_trigger):
         """
         Set dynamically a new default_trigger in the settingss
         :param default_trigger: string value
         """
         settings = SettingLoader().settings
-        settings.default_trigger_name = default_trigger
+        if cls._check_name_in_list_settings_entry(default_trigger, settings.triggers):
+            settings.default_trigger_name = default_trigger
+        else:
+            logger.debug("[Settings] default_trigger %s is not defined in settings file ", default_trigger)
 
     @staticmethod
     def set_trigger(new_trigger):

--- a/kalliope/core/ConfigurationManager/SettingEditor.py
+++ b/kalliope/core/ConfigurationManager/SettingEditor.py
@@ -23,6 +23,7 @@ class SettingEditor(object):
         for settings_entry in list_settings_entry:
             if settings_entry.name == name_to_check:
                 found = True
+                break
         return found
 
     # Options

--- a/kalliope/core/Models/settings/Settings.py
+++ b/kalliope/core/Models/settings/Settings.py
@@ -48,23 +48,22 @@ class Settings(object):
         :return: A dict of order
         :rtype: Dict
         """
-
         return {
             'default_tts_name': self.default_tts_name,
             'default_stt_name': self.default_stt_name,
             'default_trigger_name': self.default_trigger_name,
             'default_player_name': self.default_player_name,
-            'ttss': self.ttss,
-            'stts': self.stts,
-            'triggers': self.triggers,
-            'players': self.players,
+            'ttss': [e.serialize() for e in self.ttss],
+            'stts': [e.serialize() for e in self.stts],
+            'triggers': [e.serialize() for e in self.triggers],
+            'players': [e.serialize() for e in self.players],
             'rest_api': self.rest_api.serialize(),
             'cache_path': self.cache_path,
-            'resources': self.resources,
+            'resources': self.resources.serialize(),
             'variables': self.variables,
             'machine': self.machine,
             'kalliope_version': self.kalliope_version,
-            'options': self.options,
+            'options': self.options.serialize(),
             'hooks': self.hooks
         }
 

--- a/kalliope/core/Models/settings/Trigger.py
+++ b/kalliope/core/Models/settings/Trigger.py
@@ -16,9 +16,10 @@ class Trigger(SettingsEntry):
         return str(self.serialize())
 
     def serialize(self):
+        # TODO fix Trigger to remove "callback" from parameters
         return {
             'name': self.name,
-            'parameters': self.parameters
+            'parameters': dict((key, value) for key, value in self.parameters.items() if key != "callback"),
         }
 
     def __eq__(self, other):

--- a/kalliope/core/RestAPI/FlaskAPI.py
+++ b/kalliope/core/RestAPI/FlaskAPI.py
@@ -76,6 +76,7 @@ class FlaskAPI(threading.Thread):
         self.app.add_url_rule('/shutdown/', view_func=self.shutdown_server, methods=['POST'])
 
         # Settings
+        self.app.add_url_rule('/settings', view_func=self.get_current_settings, methods=['GET'])
         self.app.add_url_rule('/settings/deaf/', view_func=self.get_deaf, methods=['GET'])
         self.app.add_url_rule('/settings/deaf/', view_func=self.set_deaf, methods=['POST'])
         self.app.add_url_rule('/settings/mute/', view_func=self.get_mute, methods=['GET'])
@@ -941,3 +942,13 @@ class FlaskAPI(threading.Thread):
         logger.debug("[FlaskAPI] Overridden parameters: %s" % parameters)
 
         return parameters
+
+    def get_current_settings(self):
+        """
+        get the current settings config
+        test with curl:
+        curl -i --user admin:secret  -X GET  http://127.0.0.1:5000/settings
+        """
+        logger.debug("[FlaskAPI] get_current_settings: all")
+        data = jsonify(settings=self.settings.serialize())
+        return data, 200

--- a/kalliope/core/RestAPI/FlaskAPI.py
+++ b/kalliope/core/RestAPI/FlaskAPI.py
@@ -916,32 +916,12 @@ class FlaskAPI(threading.Thread):
             if flag_to_find in received_json:
                 flag_value = received_json[flag_to_find]
                 if is_boolean:
-                    flag_value = self.str_to_bool(flag_value)
+                    flag_value = Utils.str_to_bool(flag_value)
         except TypeError:
             # no json received
             pass
         logger.debug("[FlaskAPI] Value found for : type %s,  %s : %s" % (flag_to_find, type(flag_value), flag_value))
         return flag_value
-
-    @staticmethod
-    def str_to_bool(s):
-        if isinstance(s, bool):  # do not convert if already a boolean
-            return s
-        else:
-            if s == 'True' \
-                    or s == 'true' \
-                    or s == '1' \
-                    or s == 1 \
-                    or s == True:
-                return True
-            elif s == 'False' \
-                    or s == 'false' \
-                    or s == '0' \
-                    or s == 0 \
-                    or s == False:
-                return False
-            else:
-                return False
 
     @staticmethod
     def get_parameters_from_request(http_request):

--- a/kalliope/core/RestAPI/FlaskAPI.py
+++ b/kalliope/core/RestAPI/FlaskAPI.py
@@ -108,7 +108,6 @@ class FlaskAPI(threading.Thread):
                               methods=['GET'])
         self.app.add_url_rule('/settings/hooks/', view_func=self.set_hooks,
                               methods=['POST'])
-
         self.app.add_url_rule('/settings/variables/', view_func=self.get_variables,
                               methods=['GET'])
         self.app.add_url_rule('/settings/variables/', view_func=self.set_variables,

--- a/kalliope/core/RestAPI/FlaskAPI.py
+++ b/kalliope/core/RestAPI/FlaskAPI.py
@@ -105,6 +105,11 @@ class FlaskAPI(threading.Thread):
         self.app.add_url_rule('/settings/default_trigger/', view_func=self.set_default_trigger,
                               methods=['POST'])
 
+        self.app.add_url_rule('/settings/hooks/', view_func=self.get_hooks,
+                              methods=['GET'])
+        self.app.add_url_rule('/settings/hooks/', view_func=self.set_hooks,
+                              methods=['POST'])
+
     def run(self):
         self.app.run(host='0.0.0.0', port=int(self.port), debug=True, threaded=True, use_reloader=False)
 
@@ -243,7 +248,6 @@ class FlaskAPI(threading.Thread):
                 "Error": "Wrong parameters, 'order' not set"
             }
             return jsonify(error=data), 400
-
 
         order = request.get_json('order')
 
@@ -405,7 +409,6 @@ class FlaskAPI(threading.Thread):
             }
             return jsonify(error=data), 400
 
-
         # get deaf if present
         deaf = self.get_value_flag_from_request(http_request=request,
                                                 flag_to_find="deaf",
@@ -462,7 +465,6 @@ class FlaskAPI(threading.Thread):
             }
             return jsonify(error=data), 400
 
-
         # get mute if present
         mute = self.get_value_flag_from_request(http_request=request,
                                                 flag_to_find="mute",
@@ -510,7 +512,6 @@ class FlaskAPI(threading.Thread):
                 "Error": "Wrong parameters, 'energy_threshold' not set"
             }
             return jsonify(error=data), 400
-
 
         # get energy_threshold if present
         energy_threshold = self.get_value_flag_from_request(http_request=request,
@@ -560,7 +561,6 @@ class FlaskAPI(threading.Thread):
                 "Error": "Wrong parameters, 'ambient_noise_second' not set"
             }
             return jsonify(error=data), 400
-
 
         # get if present
         ambient_noise_second = self.get_value_flag_from_request(http_request=request,
@@ -612,7 +612,6 @@ class FlaskAPI(threading.Thread):
             }
             return jsonify(error=data), 400
 
-
         # get if present
         value = self.get_value_flag_from_request(http_request=request,
                                                  flag_to_find="default_tts",
@@ -662,7 +661,6 @@ class FlaskAPI(threading.Thread):
                 "Error": "Wrong parameters, 'default_stt' not set"
             }
             return jsonify(error=data), 400
-
 
         # get if present
         value = self.get_value_flag_from_request(http_request=request,
@@ -772,6 +770,59 @@ class FlaskAPI(threading.Thread):
 
         data = {
             "default_trigger": self.settings.default_trigger_name
+        }
+        return jsonify(data), 200
+
+    @requires_auth
+    def get_hooks(self):
+        """
+        Return the list of hooks from settings
+
+        Curl test
+        curl -i --user admin:secret  -X GET  http://127.0.0.1:5000/settings/hooks
+        """
+
+        if self.settings.hooks is not None:
+            data = {
+                "hooks": self.settings.hooks
+            }
+            return jsonify(data), 200
+
+        # if no Order instance
+        data = {
+            "error": "hooks are not defined"
+        }
+        return jsonify(error=data), 400
+
+    @requires_auth
+    def set_hooks(self):
+        """
+        Set the Kalliope Core hooks value
+
+        Curl test:
+        curl -i -H "Content-Type: application/json" --user admin:secret  -X POST \
+        -d '{"hook_name":"hook_value","hooke_name2":"hook_value2"}' http://127.0.0.1:5000/settings/hooks
+        """
+
+        if not request.get_json():
+            data = {
+                "Error": "No Parameters not"
+            }
+            return jsonify(error=data), 400
+
+        # get if present
+        value = request.get_json()
+
+        if not isinstance(value, dict):
+            data = {
+                "Error": "Hooks must be a dictionary"
+            }
+            return jsonify(error=data), 400
+
+        SettingEditor.set_hooks(hooks=value)
+
+        data = {
+            "hooks": self.settings.hooks
         }
         return jsonify(data), 200
 

--- a/kalliope/core/RestAPI/FlaskAPI.py
+++ b/kalliope/core/RestAPI/FlaskAPI.py
@@ -6,7 +6,6 @@ import time
 from flask import jsonify
 from flask import request
 from flask_cors import CORS
-from flask_restful import abort
 from werkzeug.utils import secure_filename
 
 from kalliope import Utils
@@ -89,10 +88,21 @@ class FlaskAPI(threading.Thread):
                               methods=['GET'])
         self.app.add_url_rule('/settings/energy_threshold/', view_func=self.set_energy_threshold,
                               methods=['POST'])
-
         self.app.add_url_rule('/settings/default_tts/', view_func=self.get_default_tts,
                               methods=['GET'])
         self.app.add_url_rule('/settings/default_tts/', view_func=self.set_default_tts,
+                              methods=['POST'])
+        self.app.add_url_rule('/settings/default_stt/', view_func=self.get_default_stt,
+                              methods=['GET'])
+        self.app.add_url_rule('/settings/default_stt/', view_func=self.set_default_stt,
+                              methods=['POST'])
+        self.app.add_url_rule('/settings/default_player/', view_func=self.get_default_player,
+                              methods=['GET'])
+        self.app.add_url_rule('/settings/default_player/', view_func=self.set_default_player,
+                              methods=['POST'])
+        self.app.add_url_rule('/settings/default_trigger/', view_func=self.get_default_trigger,
+                              methods=['GET'])
+        self.app.add_url_rule('/settings/default_trigger/', view_func=self.set_default_trigger,
                               methods=['POST'])
 
     def run(self):
@@ -229,7 +239,11 @@ class FlaskAPI(threading.Thread):
         :return:
         """
         if not request.get_json() or 'order' not in request.get_json():
-            abort(400)
+            data = {
+                "Error": "Wrong parameters, 'order' not set"
+            }
+            return jsonify(error=data), 400
+
 
         order = request.get_json('order')
 
@@ -386,7 +400,11 @@ class FlaskAPI(threading.Thread):
         """
 
         if not request.get_json() or 'deaf' not in request.get_json():
-            abort(400)
+            data = {
+                "Error": "Wrong parameters, 'deaf' not set"
+            }
+            return jsonify(error=data), 400
+
 
         # get deaf if present
         deaf = self.get_value_flag_from_request(http_request=request,
@@ -439,7 +457,11 @@ class FlaskAPI(threading.Thread):
         """
 
         if not request.get_json() or 'mute' not in request.get_json():
-            abort(400)
+            data = {
+                "Error": "Wrong parameters, 'mute' not set"
+            }
+            return jsonify(error=data), 400
+
 
         # get mute if present
         mute = self.get_value_flag_from_request(http_request=request,
@@ -484,7 +506,11 @@ class FlaskAPI(threading.Thread):
         """
 
         if not request.get_json() or 'energy_threshold' not in request.get_json():
-            abort(400)
+            data = {
+                "Error": "Wrong parameters, 'energy_threshold' not set"
+            }
+            return jsonify(error=data), 400
+
 
         # get energy_threshold if present
         energy_threshold = self.get_value_flag_from_request(http_request=request,
@@ -530,7 +556,11 @@ class FlaskAPI(threading.Thread):
         """
 
         if not request.get_json() or 'ambient_noise_second' not in request.get_json():
-            abort(400)
+            data = {
+                "Error": "Wrong parameters, 'ambient_noise_second' not set"
+            }
+            return jsonify(error=data), 400
+
 
         # get if present
         ambient_noise_second = self.get_value_flag_from_request(http_request=request,
@@ -577,7 +607,11 @@ class FlaskAPI(threading.Thread):
         """
 
         if not request.get_json() or 'default_tts' not in request.get_json():
-            abort(400)
+            data = {
+                "Error": "Wrong parameters, 'default_tts' not set"
+            }
+            return jsonify(error=data), 400
+
 
         # get if present
         value = self.get_value_flag_from_request(http_request=request,
@@ -587,13 +621,159 @@ class FlaskAPI(threading.Thread):
         SettingEditor.set_default_tts(default_tts_name=value)
 
         data = {
-            "default_tts": value
+            "default_tts": self.settings.default_tts_name
         }
         return jsonify(data), 200
 
+    @requires_auth
+    def get_default_stt(self):
+        """
+        Return the current default_stt value from settings
+
+        Curl test
+        curl -i --user admin:secret  -X GET  http://127.0.0.1:5000/settings/default_stt
+        """
+
+        # the default_tts settings
+        if self.settings.default_stt_name is not None:
+            data = {
+                "default_stt": self.settings.default_stt_name
+            }
+            return jsonify(data), 200
+
+        # if no Order instance
+        data = {
+            "error": "default_stt status not defined"
+        }
+        return jsonify(error=data), 400
+
+    @requires_auth
+    def set_default_stt(self):
+        """
+        Set the Kalliope Core default_stt value
+
+        Curl test:
+        curl -i -H "Content-Type: application/json" --user admin:secret  -X POST \
+        -d '{"default_stt": "myStt"}' http://127.0.0.1:5000/settings/default_stt
+        """
+
+        if not request.get_json() or 'default_stt' not in request.get_json():
+            data = {
+                "Error": "Wrong parameters, 'default_stt' not set"
+            }
+            return jsonify(error=data), 400
 
 
+        # get if present
+        value = self.get_value_flag_from_request(http_request=request,
+                                                 flag_to_find="default_stt",
+                                                 is_boolean=False)
 
+        SettingEditor.set_default_stt(default_stt_name=value)
+
+        data = {
+            "default_stt": self.settings.default_stt_name
+        }
+        return jsonify(data), 200
+
+    @requires_auth
+    def get_default_player(self):
+        """
+        Return the current default_player value from settings
+
+        Curl test
+        curl -i --user admin:secret  -X GET  http://127.0.0.1:5000/settings/default_player
+        """
+
+        # the default_player settings
+        if self.settings.default_player_name is not None:
+            data = {
+                "default_player": self.settings.default_player_name
+            }
+            return jsonify(data), 200
+
+        # if no Order instance
+        data = {
+            "error": "default_player status not defined"
+        }
+        return jsonify(error=data), 400
+
+    @requires_auth
+    def set_default_player(self):
+        """
+        Set the Kalliope Core default_player value
+
+        Curl test:
+        curl -i -H "Content-Type: application/json" --user admin:secret  -X POST \
+        -d '{"default_player": "myPlayer"}' http://127.0.0.1:5000/settings/default_player
+        """
+
+        if not request.get_json() or 'default_player' not in request.get_json():
+            data = {
+                "Error": "Wrong parameters, 'default_player' not set"
+            }
+            return jsonify(error=data), 400
+        # get if present
+        value = self.get_value_flag_from_request(http_request=request,
+                                                 flag_to_find="default_player",
+                                                 is_boolean=False)
+
+        SettingEditor.set_default_player(default_player_name=value)
+
+        data = {
+            "default_player": self.settings.default_player_name
+        }
+        return jsonify(data), 200
+
+    @requires_auth
+    def get_default_trigger(self):
+        """
+        Return the current default_trigger value from settings
+
+        Curl test
+        curl -i --user admin:secret  -X GET  http://127.0.0.1:5000/settings/default_trigger
+        """
+
+        # the default_trigger settings
+        if self.settings.default_trigger_name is not None:
+            data = {
+                "default_trigger": self.settings.default_trigger_name
+            }
+            return jsonify(data), 200
+
+        # if no Order instance
+        data = {
+            "error": "default_trigger status not defined"
+        }
+        return jsonify(error=data), 400
+
+    @requires_auth
+    def set_default_trigger(self):
+        """
+        Set the Kalliope Core default_trigger value
+
+        Curl test:
+        curl -i -H "Content-Type: application/json" --user admin:secret  -X POST \
+        -d '{"default_trigger": "myTrigger"}' http://127.0.0.1:5000/settings/default_trigger
+        """
+
+        if not request.get_json() or 'default_trigger' not in request.get_json():
+            data = {
+                "Error": "Wrong parameters, 'default_trigger' not set"
+            }
+            return jsonify(error=data), 400
+
+        # get if present
+        value = self.get_value_flag_from_request(http_request=request,
+                                                 flag_to_find="default_trigger",
+                                                 is_boolean=False)
+
+        SettingEditor.set_default_trigger(default_trigger=value)
+
+        data = {
+            "default_trigger": self.settings.default_trigger_name
+        }
+        return jsonify(data), 200
 
     def audio_analyser_callback(self, order):
         """

--- a/kalliope/core/Utils/Utils.py
+++ b/kalliope/core/Utils/Utils.py
@@ -307,9 +307,17 @@ class Utils(object):
         if isinstance(s, bool):  # do not convert if already a boolean
             return s
         else:
-            if s == 'True' or s == 'true' or s == '1':
+            if s == 'True' \
+                    or s == 'true' \
+                    or s == '1' \
+                    or s == 1 \
+                    or s == True:
                 return True
-            elif s == 'False' or s == 'false' or s == '0':
+            elif s == 'False' \
+                    or s == 'false' \
+                    or s == '0' \
+                    or s == 0 \
+                    or s == False:
                 return False
             else:
                 return False

--- a/kalliope/neurons/settings/README.md
+++ b/kalliope/neurons/settings/README.md
@@ -14,6 +14,7 @@ Currently available:
 - players
 - hooks
 - var_files
+- variable
 - deaf
 - mute
 - energy_threshold
@@ -36,7 +37,8 @@ CORE NEURON : No installation needed.
 | triggers                        | No       | list (of dict) | None    |             | Add or Update a trigger to the list                             |
 | players                         | No       | list (of dict) | None    |             | Add or Update a player to the list                              |
 | hooks                           | No       | dict           | None    |             | Update the hooks dict from the settings with the given dict     |
-| var_files                       | No       | list           | None    |             | Udate the variables from the settings with the given files path |
+| var_files                       | No       | list           | None    |             | Update variables from the settings with the given files path    |
+| variable                        | No       | dict           | None    |             | Update the variable dict from the settings with the given dict  |
 | deaf                            | No       | boolean        | None    | True, False |                                                                 |
 | mute                            | No       | boolean        | None    | True, False |                                                                 |
 | energy_threshold                | No       | int            | None    |             |                                                                 |
@@ -111,7 +113,21 @@ To update the list of text_to_speech
 ```
 
 #### Variables
-/!\ the keyword is 'var_files' !
+```yaml
+  - name: "say-hello-en"
+    signals:
+      - order: "Hello"
+    neurons:
+      - settings:
+          variable:
+            nickname: "monf"
+      - say:
+          message:
+            - "Hello {{nickname}}"
+
+```
+
+/!\ the keyword is 'var_files' for files!
 
 The {{nickname}} will be loaded in the variables.yml file.
 ```yaml

--- a/kalliope/neurons/settings/README.md
+++ b/kalliope/neurons/settings/README.md
@@ -129,7 +129,7 @@ To update the list of text_to_speech
 
 /!\ the keyword is 'var_files' for files!
 
-The {{nickname}} will be loaded in the variables.yml file.
+The {{nickname}} will be loaded from the variables.yml file.
 ```yaml
   - name: "say-hello-en"
     signals:

--- a/kalliope/neurons/settings/settings.py
+++ b/kalliope/neurons/settings/settings.py
@@ -26,6 +26,7 @@ class Settings(NeuronModule):
         - players
         - hooks
         - var_files
+        - variable
         - deaf
         - mute
         - energy_threshold
@@ -59,6 +60,7 @@ class Settings(NeuronModule):
 
         # Variables
         self.var_files = kwargs.get("var_files", None)
+        self.variable = kwargs.get("variable", None)
 
         # Not applicable yet as Variables are applied during brainloading.
         # REST API
@@ -190,6 +192,11 @@ class Settings(NeuronModule):
                     logger.debug("[Settings] Variables file %s not found", file_name)
                     return False
 
+        if self.variable:
+            if not isinstance(self.variable, dict):
+                logger.debug("[Settings] variable property %s is not a dict as it should be.", type(self.variable))
+                return False
+
         return True
 
     def _set_settings(self):
@@ -272,3 +279,6 @@ class Settings(NeuronModule):
                 # var is None has been checked previously in _is_parameters_ok() method
                 variables.update(YAMLLoader.get_config(var))
             SettingEditor.set_variables(variables)
+
+        if self.variable is not None:
+            SettingEditor.set_variables(self.variable)

--- a/kalliope/neurons/settings/settings.py
+++ b/kalliope/neurons/settings/settings.py
@@ -75,7 +75,7 @@ class Settings(NeuronModule):
 
         # Players
         if self.default_player:
-            if not self._check_name_in_list_settings_entry(self.default_player, self.settings.players):
+            if not SettingEditor._check_name_in_list_settings_entry(self.default_player, self.settings.players):
                 logger.debug("[Settings] default_player %s is not defined in settings file ",
                              self.default_player)
                 return False
@@ -92,7 +92,7 @@ class Settings(NeuronModule):
 
         # STT
         if self.default_stt:
-            if not self._check_name_in_list_settings_entry(self.default_stt, self.settings.stts):
+            if not SettingEditor._check_name_in_list_settings_entry(self.default_stt, self.settings.stts):
                 logger.debug("[Settings] default_stt %s is not defined in settings file ", self.default_stt)
                 return False
 
@@ -110,7 +110,7 @@ class Settings(NeuronModule):
 
         # TRIGGER
         if self.default_trigger:
-            if not self._check_name_in_list_settings_entry(self.default_trigger, self.settings.triggers):
+            if not SettingEditor._check_name_in_list_settings_entry(self.default_trigger, self.settings.triggers):
                 logger.debug("[Settings] default_trigger %s is not defined in settings file ",
                              self.default_trigger)
                 return False
@@ -127,7 +127,7 @@ class Settings(NeuronModule):
 
         # TTS
         if self.default_tts:
-            if not self._check_name_in_list_settings_entry(self.default_tts, self.settings.ttss):
+            if not SettingEditor._check_name_in_list_settings_entry(self.default_tts, self.settings.ttss):
                 logger.debug("[Settings] default_tts %s is not defined in settings file ", self.default_tts)
                 return False
 
@@ -272,17 +272,3 @@ class Settings(NeuronModule):
                 # var is None has been checked previously in _is_parameters_ok() method
                 variables.update(YAMLLoader.get_config(var))
             SettingEditor.set_variables(variables)
-
-    @staticmethod
-    def _check_name_in_list_settings_entry(name_to_check, list_settings_entry):
-        """
-        manage object models : STT, TRIGGERS, TTS, PLAYERS because they have "name" attributes
-        :param name_to_check: name to find in the list_settings_entry ~kalliope.core.Models.settings.SettingsEntry.SettingsEntry
-        :param list_settings_entry: the list of SettingsEntry to inspect
-        :return: True if the name_to_check corresponds to a name in the SettingsEntry list provided.
-        """
-        found = False
-        for settings_entry in list_settings_entry:
-            if settings_entry.name == name_to_check:
-                found = True
-        return found


### PR DESCRIPTION
Define new endpoints for the rest api to manage Kalliope settings dynamically.

New endpoints : 


| Method | URL                               | Action                             |
|--------|-----------------------------------|------------------------------------|
| GET    | /settings/deaf                    | Get the current deaf status        |
| POST   | /settings/deaf                    | Switch the deaf status             |
| GET    | /settings/mute                    | Get the current mute status        |
| POST   | /settings/mute                    | Switch the mute status             |
| GET    | /settings/energy_threshold        | Get the current energy_threshold   |
| POST   | /settings/energy_threshold        | Update the energy_threshold value  |
| GET    | /settings/ambient_noise_second    | Get the ambient_noise_second       |
| POST   | /settings/ambient_noise_second    | Update the ambient_noise_second    |
| GET    | /settings/hooks                   | Get the current hooks              |
| POST   | /settings/hooks                   | Update the hooks list              |
| GET    | /settings/variables               | Get the variables list             |
| POST   | /settings/variables               | Update the variables list          |
| GET    | /settings/default_tts             | Get current tts                    |
| POST   | /settings/default_tts             | Update current tts                 |
| GET    | /settings/default_stt             | Get current stt                    |
| POST   | /settings/default_stt             | Update current stt                 |
| GET    | /settings/default_player          | Get the current player             |
| POST   | /settings/default_player          | Update current player              |
| GET    | /settings/default_trigger         | Get the current trigger            |
| POST   | /settings/default_trigger         | Update the current trigger         |
