### PR TITLE
Fix cortex when saving string

### DIFF
--- a/kalliope/core/Cortex.py
+++ b/kalliope/core/Cortex.py
@@ -113,8 +113,8 @@ class Cortex(with_metaclass(Singleton, object)):
                 if Utils.is_containing_bracket(value):
                     # if the key exist in the temp dict we can load it with jinja
                     value = jinja2.Template(value).render(Cortex.temp)
-                    if value:
-                        Cortex.save(key, value)
-                        order_saved = True
+                if value:
+                    Cortex.save(key, value)
+                    order_saved = True
 
         return order_saved


### PR DESCRIPTION
would be nice to have the last stt in memory

A quick way to test the feature could be this:
```
  - name: "test-stt-1"
    signals:
      - order: "Testing"
    neurons:
      - say:
          message:
            - "Key values in memory are {{ kalliope_memory }}"
      - neurotransmitter:
          from_answer_link:
            - synapse: "test-stt-2"
              answers:
                - 'foo'
                - 'bar'
          default: "test-stt-2"

  - name: "test-stt-2"
    signals:
      - order: "test-stt-2"
    neurons:
      - say:
          message:
            - "Last SST is {{ kalliope_memory['kalliope_last_stt_message'] }}"
```
