### PR TITLE
Add new matching-type and small fix for the stt correction

### DIFF
--- a/Tests/files/test-stt-correction.yml
+++ b/Tests/files/test-stt-correction.yml
@@ -1,2 +1,4 @@
 - input: "test"
   output: "order"
+- input: "hello the"
+  output: "i am"

--- a/Tests/test_order_analyser.py
+++ b/Tests/test_order_analyser.py
@@ -562,11 +562,24 @@ class TestOrderAnalyser(unittest.TestCase):
         cls.assertEqual(expected_signal_order, OrderAnalyser.get_signal_order(signal=signal2))
 
         # signal order is a dict and `text` element is missing
-        expected_signal_order = "" # not found !
+        expected_signal_order = ""  # not found !
         cls.assertEqual(expected_signal_order, OrderAnalyser.get_signal_order(signal=signal3))
 
+    def test_get_not_containing_words(cls):
+        signal1 = Signal(name="order", parameters={"matching-type": "not-contain", "excluded_words": ["that", "is"]})
 
-# TODO def test_get_not_containing_words(cls):
+        # get the correct list of excluded words
+        expected_list_excluded_words = ["that", "is"]
+        cls.assertEqual(expected_list_excluded_words, OrderAnalyser.get_not_containing_words(signal=signal1))
+
+        # assert it returns None when a str is provided and not a list
+        signal1 = Signal(name="order", parameters={"matching-type": "not-contain", "excluded_words": "that"})
+        cls.assertIsNone(OrderAnalyser.get_not_containing_words(signal=signal1))
+
+        # assert it returns None when `excluded_words` is not provided
+        signal1 = Signal(name="order", parameters={"matching-type": "not-contain"})
+        cls.assertIsNone(OrderAnalyser.get_not_containing_words(signal=signal1))
+
 
 # TODO def test_get_list_match_synapse(cls):
 

--- a/Tests/test_order_analyser.py
+++ b/Tests/test_order_analyser.py
@@ -376,6 +376,8 @@ class TestOrderAnalyser(unittest.TestCase):
         self.assertTrue(OrderAnalyser.is_order_matching_signal(user_order=test_order,
                                                                signal=test_signal))
 
+        # TODO more tests
+
     def test_override_order_with_correction(self):
         # test with provided correction
         order = "this is my test"
@@ -544,11 +546,29 @@ class TestOrderAnalyser(unittest.TestCase):
         self.assertEqual(OrderAnalyser.order_correction(order=testing_order, signal=testing_signals),
                          expected_fixed_order)
 
+    def test_get_signal_order(cls):
+        signal1 = Signal(name="order", parameters="expected order in the signal")
+        signal2 = Signal(name="order", parameters={"matching-type": "strict",
+                                                   "text": "that is the sentence"})
+        signal3 = Signal(name="order", parameters={"matching-type": "strict",
+                                                   "fake-value": "that is the sentence"})
+
+        # Signal order is a str
+        expected_signal_order = "expected order in the signal"
+        cls.assertEqual(expected_signal_order, OrderAnalyser.get_signal_order(signal=signal1))
+
+        # Signal order is a dict
+        expected_signal_order = "that is the sentence"
+        cls.assertEqual(expected_signal_order, OrderAnalyser.get_signal_order(signal=signal2))
+
+        # signal order is a dict and `text` element is missing
+        expected_signal_order = "" # not found !
+        cls.assertEqual(expected_signal_order, OrderAnalyser.get_signal_order(signal=signal3))
+
+
+# TODO def test_get_not_containing_words(cls):
+
+# TODO def test_get_list_match_synapse(cls):
 
 if __name__ == '__main__':
     unittest.main()
-
-    # suite = unittest.TestSuite()
-    # suite.addTest(TestOrderAnalyser("test_get_matching_synapse"))
-    # runner = unittest.TextTestRunner()
-    # runner.run(suite)

--- a/Tests/test_order_analyser.py
+++ b/Tests/test_order_analyser.py
@@ -1,7 +1,6 @@
 import os
 import unittest
 
-
 from kalliope.core.Models import Brain
 from kalliope.core.Models import Neuron
 from kalliope.core.Models import Synapse
@@ -11,7 +10,6 @@ from kalliope.core.OrderAnalyser import OrderAnalyser
 
 
 class TestOrderAnalyser(unittest.TestCase):
-
     """Test case for the OrderAnalyser Class"""
 
     def setUp(self):
@@ -175,12 +173,12 @@ class TestOrderAnalyser(unittest.TestCase):
         self.assertEqual(OrderAnalyser._get_split_order_without_bracket(order_to_test), expected_result,
                          "With spaced brackets Fails to return the expected list")
 
-        order_to_test = "this is the {{order }}"    # left bracket without space
+        order_to_test = "this is the {{order }}"  # left bracket without space
         expected_result = ["this", "is", "the"]
         self.assertEqual(OrderAnalyser._get_split_order_without_bracket(order_to_test), expected_result,
                          "Left brackets Fails to return the expected list")
 
-        order_to_test = "this is the {{ order}}"    # right bracket without space
+        order_to_test = "this is the {{ order}}"  # right bracket without space
         expected_result = ["this", "is", "the"]
         self.assertEqual(OrderAnalyser._get_split_order_without_bracket(order_to_test), expected_result,
                          "Right brackets Fails to return the expected list")
@@ -232,6 +230,62 @@ class TestOrderAnalyser(unittest.TestCase):
 
         self.assertTrue(OrderAnalyser.is_normal_matching(user_order=test_order,
                                                          signal_order=test_signal))
+
+    def test_is_not_contain_matching(self):
+        # Test the normal matching use case with no excluded words matching in the order
+        test_order = "expected order in the signal"
+        test_signal = "expected order in the signal"
+        excluded_words = "test"
+
+        self.assertTrue(OrderAnalyser.is_not_contain_matching(user_order=test_order,
+                                                              signal_order=test_signal,
+                                                              not_containing_words=excluded_words))
+
+        # test with one excluded word matching in the order.
+        test_order = "expected order in the signal"
+        test_signal = "expected"
+        excluded_words = ["order"]
+
+        self.assertFalse(OrderAnalyser.is_not_contain_matching(user_order=test_order,
+                                                               signal_order=test_signal,
+                                                               not_containing_words=excluded_words))
+
+        # test with multiple excluded word and only one matching in the order.
+        test_order = "expected order in the signal"
+        test_signal = "expected"
+        excluded_words = ["blabla", "order", "bloblo"]
+
+        self.assertFalse(OrderAnalyser.is_not_contain_matching(user_order=test_order,
+                                                               signal_order=test_signal,
+                                                               not_containing_words=excluded_words))
+
+        # test with multiple excluded word and multiple are matching in the order.
+        test_order = "expected order in the signal"
+        test_signal = "expected"
+        excluded_words = ["in", "order", "in"]
+
+        self.assertFalse(OrderAnalyser.is_not_contain_matching(user_order=test_order,
+                                                               signal_order=test_signal,
+                                                               not_containing_words=excluded_words))
+
+        # test with multiple excluded word and only none is matching the order
+        test_order = "expected order in the signal"
+        test_signal = "expected order in"
+        excluded_words = ["blublu", "blabla", "bloblo"]
+
+        self.assertTrue(OrderAnalyser.is_not_contain_matching(user_order=test_order,
+                                                              signal_order=test_signal,
+                                                              not_containing_words=excluded_words))
+
+        # test with multiple excluded word and brackets.
+        test_order = "expected order the signal"
+        test_signal = "expected order {{ in }}"
+        excluded_words = ["blublu", "blabla", "in"]
+
+        self.assertTrue(OrderAnalyser.is_not_contain_matching(user_order=test_order,
+                                                              signal_order=test_signal,
+                                                              not_containing_words=excluded_words))
+
 
     def test_is_strict_matching(self):
         # same order with same amount of word

--- a/Tests/test_order_analyser.py
+++ b/Tests/test_order_analyser.py
@@ -48,7 +48,7 @@ class TestOrderAnalyser(unittest.TestCase):
                                                     ]})
         signal13 = Signal(name="order", parameters={"matching-type": "not-contain",
                                                     "text": "testing the not contain",
-                                                    "excluded_words": ["that", "in"]})
+                                                    "excluded-words": ["that", "in"]})
 
         synapse1 = Synapse(name="Synapse1", neurons=[neuron1, neuron2], signals=[signal1])
         synapse2 = Synapse(name="Synapse2", neurons=[neuron3, neuron4], signals=[signal2])
@@ -596,7 +596,7 @@ class TestOrderAnalyser(unittest.TestCase):
         cls.assertEqual(expected_signal_order, OrderAnalyser.get_signal_order(signal=signal3))
 
     def test_get_not_containing_words(cls):
-        signal1 = Signal(name="order", parameters={"matching-type": "not-contain", "excluded_words": ["that", "is"]})
+        signal1 = Signal(name="order", parameters={"matching-type": "not-contain", "excluded-words": ["that", "is"]})
 
         # get the correct list of excluded words
         expected_list_excluded_words = ["that", "is"]
@@ -609,8 +609,6 @@ class TestOrderAnalyser(unittest.TestCase):
         # assert it returns None when `excluded_words` is not provided
         signal1 = Signal(name="order", parameters={"matching-type": "not-contain"})
         cls.assertIsNone(OrderAnalyser.get_not_containing_words(signal=signal1))
-
-    # TODO def test_get_list_match_synapse(cls):
 
 
 if __name__ == '__main__':

--- a/Tests/test_order_analyser.py
+++ b/Tests/test_order_analyser.py
@@ -286,7 +286,6 @@ class TestOrderAnalyser(unittest.TestCase):
                                                               signal_order=test_signal,
                                                               not_containing_words=excluded_words))
 
-
     def test_is_strict_matching(self):
         # same order with same amount of word
         test_order = "expected order in the signal"
@@ -363,18 +362,19 @@ class TestOrderAnalyser(unittest.TestCase):
         self.assertFalse(OrderAnalyser.is_ordered_strict_matching(user_order=test_order,
                                                                   signal_order=test_signal))
 
-    def test_is_order_matching(self):
+    def test_is_order_matching_signal(self):
         # all lowercase
         test_order = "expected order in the signal"
-        test_signal = "expected order in the signal"
-        self.assertTrue(OrderAnalyser.is_order_matching(user_order=test_order,
-                                                        signal_order=test_signal))
+        signal1 = Signal(name="order", parameters="expected order in the signal")
+        test_signal = signal1
+        self.assertTrue(OrderAnalyser.is_order_matching_signal(user_order=test_order,
+                                                               signal=test_signal))
 
         # with uppercase
         test_order = "Expected Order In The Signal"
-        test_signal = "expected order in the signal"
-        self.assertTrue(OrderAnalyser.is_order_matching(user_order=test_order,
-                                                        signal_order=test_signal))
+        test_signal = signal1
+        self.assertTrue(OrderAnalyser.is_order_matching_signal(user_order=test_order,
+                                                               signal=test_signal))
 
     def test_override_order_with_correction(self):
         # test with provided correction

--- a/Tests/test_order_analyser.py
+++ b/Tests/test_order_analyser.py
@@ -428,6 +428,68 @@ class TestOrderAnalyser(unittest.TestCase):
         self.assertEqual(OrderAnalyser.order_correction(order=testing_order, signal=testing_signals),
                          expected_fixed_order)
 
+        # test with stt-correction that override multiple words.
+        testing_order = "thus is my test"
+
+        signal_parameter = {
+            "stt-correction": [
+                {"input": "is my test",
+                 "output": "is overridden"}
+            ]
+        }
+        testing_signals = Signal(name="test",
+                                 parameters=signal_parameter)
+
+        expected_fixed_order = "thus is overridden"
+        self.assertEqual(OrderAnalyser.order_correction(order=testing_order, signal=testing_signals),
+                         expected_fixed_order)
+
+        # test stt-correction that override one word with multiple words.
+        testing_order = "thus is my test"
+
+        signal_parameter = {
+            "stt-correction": [
+                {"input": "test",
+                 "output": "is overridden"}
+            ]
+        }
+        testing_signals = Signal(name="test",
+                                 parameters=signal_parameter)
+
+        expected_fixed_order = "thus is my is overridden"
+        self.assertEqual(OrderAnalyser.order_correction(order=testing_order, signal=testing_signals),
+                         expected_fixed_order)
+
+        # test stt-correction that multiple words override files one word.
+        testing_order = "thus is my test"
+
+        signal_parameter = {
+            "stt-correction": [
+                {"input": "test",
+                 "output": "the overridden"}
+            ],
+            "stt-correction-file": self.correction_file_to_test
+        }
+        testing_signals = Signal(name="test",
+                                 parameters=signal_parameter)
+
+        expected_fixed_order = "thus is my the overridden"
+        self.assertEqual(OrderAnalyser.order_correction(order=testing_order, signal=testing_signals),
+                         expected_fixed_order)
+
+        # test stt-correction with multiple inputs words in file.
+        testing_order = "hello the test"
+
+        signal_parameter = {
+            "stt-correction-file": self.correction_file_to_test
+        }
+        testing_signals = Signal(name="test",
+                                 parameters=signal_parameter)
+
+        expected_fixed_order = "i am order"
+        self.assertEqual(OrderAnalyser.order_correction(order=testing_order, signal=testing_signals),
+                         expected_fixed_order)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Tests/test_trigger_launcher.py
+++ b/Tests/test_trigger_launcher.py
@@ -25,6 +25,9 @@ class TestTriggerLauncher(unittest.TestCase):
         trigger2 = Trigger("Trigger2", {'pmdl_file': "trigger/snowboy/resources/kalliope-FR-6samples.pmdl"})
         settings = Settings()
         settings.triggers = [trigger1, trigger2]
+        trigger_folder = None
+        if settings.resources:
+            trigger_folder = settings.resources.trigger_folder
         with mock.patch("kalliope.core.Utils.get_dynamic_class_instantiation") as mock_get_class_instantiation:
             # Get the trigger 1
             settings.default_trigger_name = "Trigger"
@@ -33,7 +36,8 @@ class TestTriggerLauncher(unittest.TestCase):
 
             mock_get_class_instantiation.assert_called_once_with(package_name="trigger",
                                                                  module_name=trigger1.name,
-                                                                 parameters=trigger1.parameters)
+                                                                 parameters=trigger1.parameters,
+                                                                 resources_dir=trigger_folder)
             mock_get_class_instantiation.reset_mock()
 
             # Get the trigger 2
@@ -43,5 +47,6 @@ class TestTriggerLauncher(unittest.TestCase):
 
             mock_get_class_instantiation.assert_called_once_with(package_name="trigger",
                                                                  module_name=trigger2.name,
-                                                                 parameters=trigger2.parameters)
+                                                                 parameters=trigger2.parameters,
+                                                                 resources_dir=trigger_folder)
             mock_get_class_instantiation.reset_mock()

--- a/docs/brain/signals/order.md
+++ b/docs/brain/signals/order.md
@@ -12,7 +12,7 @@ Other way to write an order, with parameters:
 |---------------------|---------------------|---------|---------------------------------------------|--------------------------------------------------------|
 | text                | YES                 |         |                                             | The order to match                                     |
 | matching-type       | NO                  | normal  | normal, strict, ordered-strict, not-contain | Type of matching. See explanation bellow               |
-| words-in-order      | only if not-contain |         |                                             | The words which are present in the order to prevent other orders to be execute |
+| excluded_words      | only if not-contain |         |                                             | The words which are present in the order to prevent other orders to be execute |
 | stt-correction      | NO                  |         |                                             | List of words from the order to replace by other words |
 | stt-correction-file | NO                  |         |                                             | Same as stt-correction but load words from a YAML file |
 
@@ -44,14 +44,14 @@ When you will pronounce "say hello", it will trigger both synapses. To prevent t
 - **normal**: Will match if all words are present in the spoken order.
 - **strict**: All word are present. No more word must be present in the spoken order.
 - **ordered-strict**: All word are present, no more word and all word are in the same order as defined in the signal.
-- **not-contain**: The list of the given words in words-in-order will prevent that this synapse get execute if you call another synapse with a similar order which contains these words.
+- **not-contain**: It will match only if all the words are present in the spoken order WITHOUT the excluded_words .
 
 
 ```yaml
 - order: 
     text: "what is the weather"
     matching-type: "not-contain"
-    words-in-order:
+    excluded_words:
       - "in"
       - "at"
       - "on"

--- a/docs/brain/signals/order.md
+++ b/docs/brain/signals/order.md
@@ -12,7 +12,7 @@ Other way to write an order, with parameters:
 |---------------------|---------------------|---------|---------------------------------------------|--------------------------------------------------------|
 | text                | YES                 |         |                                             | The order to match                                     |
 | matching-type       | NO                  | normal  | normal, strict, ordered-strict, not-contain | Type of matching. See explanation bellow               |
-| excluded_words      | only if not-contain |         |                                             | The words which are present in the order to prevent other orders to be execute |
+| excluded-words      | only if not-contain |         |                                             | The words which are present in the order to prevent other orders to be execute |
 | stt-correction      | NO                  |         |                                             | List of words from the order to replace by other words |
 | stt-correction-file | NO                  |         |                                             | Same as stt-correction but load words from a YAML file |
 
@@ -44,14 +44,14 @@ When you will pronounce "say hello", it will trigger both synapses. To prevent t
 - **normal**: Will match if all words are present in the spoken order.
 - **strict**: All word are present. No more word must be present in the spoken order.
 - **ordered-strict**: All word are present, no more word and all word are in the same order as defined in the signal.
-- **not-contain**: It will match only if all the words are present in the spoken order WITHOUT the excluded_words .
+- **not-contain**: It will match only if all the words are present in the spoken order WITHOUT the excluded-words .
 
 
 ```yaml
 - order: 
     text: "what is the weather"
     matching-type: "not-contain"
-    excluded_words:
+    excluded-words:
       - "in"
       - "at"
       - "on"

--- a/kalliope/core/NeuronModule.py
+++ b/kalliope/core/NeuronModule.py
@@ -24,6 +24,7 @@ class InvalidParameterException(NeuronExceptions):
     """
     Some Neuron parameters are invalid.
     """
+
     def __init__(self, message):
         # Call the base class constructor with the parameters it needs
         super(InvalidParameterException, self).__init__(message)
@@ -65,6 +66,7 @@ class NeuronModule(object):
     This Abstract Class is representing main Class for Neuron.
     Each Neuron must implement this Class.
     """
+
     def __init__(self, **kwargs):
         """
         Class used by neuron for talking
@@ -252,8 +254,8 @@ class NeuronModule(object):
 
     @staticmethod
     def is_order_matching(order_said, order_match):
-        return OrderAnalyser().is_order_matching(signal_order=order_match,
-                                                 user_order=order_said)
+        return OrderAnalyser().is_normal_matching(signal_order=order_match,
+                                                  user_order=order_said)
 
     @staticmethod
     def _get_content_of_file(real_file_template_path):

--- a/kalliope/core/OrderAnalyser.py
+++ b/kalliope/core/OrderAnalyser.py
@@ -268,12 +268,8 @@ class OrderAnalyser:
     @classmethod
     def is_order_matching_signal(cls, user_order, signal):
         """
-        return True if the user_order matches the signal_order following the expected_order_type
-        where "expected_order_type" is in
-        - normal: normal matching. all words are present in the user_order. this is the default
-        - strict: only word in the user order match. no more word
-        - ordered-strict: only word in the user order and in the same order
-        - not-contain: skip order if not containing words are present
+        return True if the user_order matches the provided signal. False otherwise
+        Note: it applies `stt-correction` and handles `not-contain` matching type.
         :param user_order: order from the user
         :param signal: The signal to compare with the user_order
         :return: True if the order match

--- a/kalliope/core/OrderAnalyser.py
+++ b/kalliope/core/OrderAnalyser.py
@@ -120,14 +120,14 @@ class OrderAnalyser:
     def get_not_containing_words(signal):
         not_containing_words = None
         try:
-            not_containing_words = signal.parameters['excluded_words']
+            not_containing_words = signal.parameters['excluded-words']
             if isinstance(not_containing_words, str):
                 logger.debug("[OrderAnalyser] not contain words should be a list not a string.")
                 not_containing_words = None
                 raise KeyError
             logger.debug("[OrderAnalyser] not-contain provided by user : %s" % not_containing_words)
         except KeyError:
-            logger.debug("[OrderAnalyser] No excluded_words provided, change expected_matching_type to normal")
+            logger.debug("[OrderAnalyser] No excluded-words provided, change expected_matching_type to normal")
         return not_containing_words
 
     @staticmethod

--- a/kalliope/core/OrderAnalyser.py
+++ b/kalliope/core/OrderAnalyser.py
@@ -123,6 +123,7 @@ class OrderAnalyser:
             not_containing_words = signal.parameters['excluded_words']
             if isinstance(not_containing_words, str):
                 logger.debug("[OrderAnalyser] not contain words should be a list not a string.")
+                not_containing_words = None
                 raise KeyError
             logger.debug("[OrderAnalyser] not-contain provided by user : %s" % not_containing_words)
         except KeyError:

--- a/kalliope/core/OrderAnalyser.py
+++ b/kalliope/core/OrderAnalyser.py
@@ -145,13 +145,13 @@ class OrderAnalyser:
     def get_not_containing_words(signal):
         not_containing_words = None
         try:
-            not_containing_words = signal.parameters['words-in-order']
+            not_containing_words = signal.parameters['excluded_words']
             if isinstance(not_containing_words, str):
                 logger.debug("[OrderAnalyser] not contain words should be a list not a string.")
                 raise KeyError
             logger.debug("[OrderAnalyser] not-contain provided by user : %s" % not_containing_words)
         except KeyError:
-            logger.debug("[OrderAnalyser] No words-in-order provided, change expected_matching_type to normal")
+            logger.debug("[OrderAnalyser] No excluded_words provided, change expected_matching_type to normal")
         return not_containing_words
 
     @staticmethod

--- a/kalliope/core/OrderAnalyser.py
+++ b/kalliope/core/OrderAnalyser.py
@@ -294,7 +294,7 @@ class OrderAnalyser:
         signal_order = signal_order.lower()
 
         if expected_order_type in matching_type_function:
-            if expected_order_type is "not-contain":
+            if expected_order_type == "not-contain":
                 not_containing_words = cls.get_not_containing_words(signal)
                 return cls.is_not_contain_matching(user_order, signal_order, not_containing_words)
             else:

--- a/kalliope/core/TriggerLauncher.py
+++ b/kalliope/core/TriggerLauncher.py
@@ -20,6 +20,10 @@ class TriggerLauncher(object):
         :return: The instance of Trigger 
         :rtype: Trigger
         """
+        trigger_folder = None
+        if settings.resources:
+            trigger_folder = settings.resources.trigger_folder
+            
         trigger_instance = None
         for trigger in settings.triggers:
             if trigger.name == settings.default_trigger_name:
@@ -29,6 +33,7 @@ class TriggerLauncher(object):
                     "TriggerLauncher: Start trigger %s with parameters: %s" % (trigger.name, trigger.parameters))
                 trigger_instance = Utils.get_dynamic_class_instantiation(package_name="trigger",
                                                                          module_name=trigger.name,
-                                                                         parameters=trigger.parameters)
+                                                                         parameters=trigger.parameters,
+                                                                         resources_dir=trigger_folder)
                 break
         return trigger_instance


### PR DESCRIPTION
- Add matching-type "not-contain"
- Small fix for the STT-Correction:
   - if the order is not in lower case and the correction is or the opposite, it will not be found
   - if one stt-correction contains more than one word, it will not be found

- Add docs for the new matching-type