### PR TITLE
piCore - boost Kalliope - all will run in memory

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,6 +59,7 @@ pages:
       - ansible_playbook: "brain/neurons/ansible_playbook.md"
       - brain: "brain/neurons/brain.md"
       - debug: "brain/neurons/debug.md"
+      - kalliope_version: "brain/neurons/kalliope_version.md"
       - kill_switch: "brain/neurons/kill_switch.md"
       - mqtt_publisher: "brain/neurons/mqtt_publisher.md"
       - neurotimer: "brain/neurons/neurotimer.md"


### PR DESCRIPTION
Hi,

I saw Kalliope could be run on debian, raspbian and even docker.
Then I ask you to try given us a Kalliope that could be run on piCore (tinyCore OS that run on RAM with only around 15 mb for its core) : 
[https://iotbytes.wordpress.com/picore-tiny-core-linux-on-raspberry-pi/](url)
[https://brezular.com/2017/12/14/linux-picore-on-raspberry-pi-first-steps/](url)

You just have to pay attention to natively integrate in your image : WiFi (to interact in the network and internet) and Bluetooth (to connect centralized speaker).

Perhaps it should also be interesseting to integrate the lightweight Moquette MQTT broker [https://moquette-io.github.io/moquette/](url) then all the Kalliope core and plugins could be run on RAM.

Sincerely thank you to take this in consideration.