### PR TITLE
#548 fix disabled synapse with event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+v0.5.4 / TBD
+===================
+- Fix #548: SynapseLauncher checks if the synapse is `enabled` before launching it. 
+
 v0.5.3 / 2019-01-15
 ===================
 - Fix: Update request lib to fix security vulnerabilities.

--- a/Tests/test_synapse_launcher.py
+++ b/Tests/test_synapse_launcher.py
@@ -31,10 +31,12 @@ class TestSynapseLauncher(unittest.TestCase):
         self.synapse1 = Synapse(name="Synapse1", neurons=[neuron1, neuron2], signals=[signal1])
         self.synapse2 = Synapse(name="Synapse2", neurons=[neuron3, neuron4], signals=[signal2])
         self.synapse3 = Synapse(name="Synapse3", neurons=[neuron2, neuron4], signals=[signal3])
+        self.synapse4 = Synapse(name="Synapse4", neurons=[neuron4], signals=[signal3])
 
         self.all_synapse_list = [self.synapse1,
                                  self.synapse2,
-                                 self.synapse3]
+                                 self.synapse3,
+                                 self.synapse4]
 
         self.brain_test = Brain(synapses=self.all_synapse_list)
         self.settings_test = Settings()
@@ -82,6 +84,16 @@ class TestSynapseLauncher(unittest.TestCase):
                                                            brain=self.brain_test,
                                                            overriding_parameter_dict=overriding_parameter_dict)
                 cortex_mock.assert_called_with(overriding_parameter_dict)
+
+        # check disable synapse is not run
+        self.synapse4.enabled = False
+        LifoManager.clean_saved_lifo()
+        with mock.patch("kalliope.core.Lifo.LIFOBuffer.execute"):
+            SynapseLauncher.start_synapse_by_list_name(["Synapse4"], brain=self.brain_test)
+            # we expect that the lifo has NOT been loaded with the disabled synapse
+            expected_result = [[]]
+            lifo_buffer = LifoManager.get_singleton_lifo()
+            self.assertEqual(expected_result, lifo_buffer.lifo_list)
 
     def test_start_synapse_by_list_name(self):
         # test to start a list of synapse

--- a/kalliope/core/SynapseLauncher.py
+++ b/kalliope/core/SynapseLauncher.py
@@ -50,7 +50,9 @@ class SynapseLauncher(object):
                 if not synapse_to_start:
                     raise SynapseNameNotFound("[SynapseLauncher] The synapse name \"%s\" does not exist "
                                               "in the brain file" % name)
-                list_synapse_object_to_start.append(synapse_to_start)
+                if synapse_to_start.enabled:
+                    list_synapse_object_to_start.append(synapse_to_start)
+                else: logger.debug("[SynapseLauncher] Synapse not activated: %s " % synapse_to_start)
 
             # run the LIFO with all synapse
             if new_lifo:


### PR DESCRIPTION
Fix - #548
On the synpaseLauncher if the synapse is enabled it is put it in the LIFO queue.  Otherwise it logs the name of the disabled synapse and does not put it in the queue.