### PR TITLE
fix version of numpy

### DIFF
--- a/install/files/python_requirements.txt
+++ b/install/files/python_requirements.txt
@@ -6,6 +6,7 @@ markupsafe>=1.1.1
 pyaudio>=0.2.11
 pyasn1>=0.4.5
 ansible>=2.9.5
+numpy==1.18.4
 jinja2>=2.10.1
 cffi>=1.12.3
 ipaddress>=1.0.17

--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,7 @@ setup(
         'pyaudio>=0.2.11',
         'pyasn1>=0.4.5',
         'ansible>=2.9.5',
+        'numpy==1.18.4',
         'jinja2>=2.10.1',
         'cffi>=1.12.3',
         'ipaddress>=1.0.17',


### PR DESCRIPTION
bug fix for lib installation (numpy fix version )
the cause is a problem during installation, pip3 installs a pre-version of numpy which stops the installation of kalliopé