### PR TITLE
Remove sox dependency

### DIFF
--- a/docker/official_image/ubuntu_18_04.dockerfile
+++ b/docker/official_image/ubuntu_18_04.dockerfile
@@ -17,7 +17,7 @@ RUN echo "deb http://us.archive.ubuntu.com/ubuntu/ bionic  multiverse" >> /etc/a
 RUN apt-get update && apt-get install -y \
     git python3-dev libsmpeg0 libttspico-utils libsmpeg0 flac \
     libffi-dev libffi-dev libssl-dev portaudio19-dev build-essential \
-    sox libatlas3-base mplayer wget vim sudo locales alsa-base alsa-utils \
+    libatlas3-base mplayer wget vim sudo locales alsa-base alsa-utils \
     python3-pip pulseaudio-utils libasound2-plugins \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker/testing_debian10.dockerfile
+++ b/docker/testing_debian10.dockerfile
@@ -7,7 +7,7 @@ RUN sed -i -- 's/buster main/buster main contrib non-free/g' /etc/apt/sources.li
 RUN apt-get update && apt-get install -y \
     git python3-dev libpython3-dev libsmpeg0 libttspico-utils libsmpeg0 flac \
     libffi-dev libffi-dev libssl-dev portaudio19-dev build-essential \
-    sox libatlas3-base mplayer wget vim sudo locales \
+    libatlas3-base mplayer wget vim sudo locales \
     python3-distutils pulseaudio-utils libasound2-plugins python3-pyaudio libasound-dev \
     libportaudio2 libportaudiocpp0 ffmpeg \
     && rm -rf /var/lib/apt/lists/*

--- a/docker/testing_ubuntu_18_04.dockerfile
+++ b/docker/testing_ubuntu_18_04.dockerfile
@@ -7,7 +7,7 @@ RUN echo "deb http://us.archive.ubuntu.com/ubuntu/ bionic  multiverse" >> /etc/a
 RUN apt-get update && apt-get install -y \
     git python3-dev libsmpeg0 libttspico-utils libsmpeg0 flac \
     libffi-dev libffi-dev libssl-dev portaudio19-dev build-essential \
-    sox libatlas3-base mplayer wget vim sudo locales alsa-base alsa-utils \
+    libatlas3-base mplayer wget vim sudo locales alsa-base alsa-utils \
     python3-distutils pulseaudio-utils libasound2-plugins python3-pyaudio libasound-dev \
     libportaudio2 libportaudiocpp0 ffmpeg \
     && rm -rf /var/lib/apt/lists/*

--- a/docs/installation/debian.md
+++ b/docs/installation/debian.md
@@ -23,7 +23,7 @@ sudo apt-get update
 sudo apt-get install -y \
     git python3-dev libpython3-dev libsmpeg0 libttspico-utils flac \
     libffi-dev libssl-dev portaudio19-dev build-essential \
-    sox libatlas3-base mplayer wget vim sudo locales \
+    libatlas3-base mplayer wget vim sudo locales \
     pulseaudio-utils libasound2-plugins python3-pyaudio libasound-dev \
     libportaudio2 libportaudiocpp0 ffmpeg
 ```

--- a/docs/installation/raspbian.md
+++ b/docs/installation/raspbian.md
@@ -30,7 +30,7 @@ Install the required system libraries and software:
 ```bash
 sudo apt-get update
 sudo apt-get install -y git python3-dev libsmpeg0 \
-    flac libffi-dev portaudio19-dev build-essential libssl-dev sox libatlas3-base mplayer libyaml-dev libpython3-dev libjpeg-dev ffmpeg pulseaudio
+    flac libffi-dev portaudio19-dev build-essential libssl-dev libatlas3-base mplayer libyaml-dev libpython3-dev libjpeg-dev ffmpeg pulseaudio
 ```
 
 On Raspberry Pi OS **Buster**, the default TTS engine is not installable directly from the package manager. Run command below to install it manually:

--- a/docs/installation/ubuntu.md
+++ b/docs/installation/ubuntu.md
@@ -11,7 +11,7 @@ sudo apt update
 sudo apt install -y \
     git python3-dev python3.7-dev libsmpeg0 libttspico-utils flac \
     libffi-dev libssl-dev portaudio19-dev build-essential \
-    sox libatlas3-base mplayer wget vim sudo locales alsa-base alsa-utils \
+    libatlas3-base mplayer wget vim sudo locales alsa-base alsa-utils \
     pulseaudio-utils libasound2-plugins python3-pyaudio libasound-dev \
     libportaudio2 libportaudiocpp0 ffmpeg 
 ```

--- a/docs/settings/tts/pico2wave.md
+++ b/docs/settings/tts/pico2wave.md
@@ -6,7 +6,6 @@ This TTS is based on the SVOX picoTTS engine
 | ---------- | -------- | ------------------ | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
 | language   | yes      |                    | 6 languages  | List of supported languages in the Note section                                                                                          |
 | cache      | no       | TRUE               | True,  False | True if you want to use the cache with this TTS                                                                                          |
-| samplerate | no       |                    | int          | Pico2wave creates 16 khz files but not all USB devices support this. Set a value to convert to a specific samplerate. For Example: 44100 |
 | path       | no       | /usr/bin/pico2wave |              | Path to the Pico2wave binary. If not set, Kalliope will try to load it from the environment                                              | convert to a specific samplerate. For Example: 44100 |
 
 ## Settings example

--- a/install/files/deb-packages_requirements.txt
+++ b/install/files/deb-packages_requirements.txt
@@ -3,7 +3,6 @@ portaudio19-dev
 build-essential
 libssl-dev
 libffi-dev
-sox
 libatlas3-base
 mplayer
 libav-tools

--- a/install/files/python_requirements.txt
+++ b/install/files/python_requirements.txt
@@ -23,7 +23,6 @@ transitions>=0.6.9
 sounddevice>=0.3.13
 SoundFile>=0.10.2
 pyalsaaudio>=0.8.4
-sox>=1.3.7
 paho-mqtt>=1.4.0
 voicerss_tts>=1.0.6
 gTTS>=2.0.3

--- a/install/rpi_install_kalliope.sh
+++ b/install/rpi_install_kalliope.sh
@@ -28,7 +28,7 @@ install_default_packages(){
     sudo apt-get update
     sudo apt-get install -y git python3-dev libsmpeg0 \
     flac libffi-dev libffi-dev libssl-dev portaudio19-dev build-essential \
-    libssl-dev libffi-dev sox libatlas3-base mplayer libyaml-dev libpython3-dev libjpeg-dev
+    libssl-dev libffi-dev libatlas3-base mplayer libyaml-dev libpython3-dev libjpeg-dev
     sudo apt-get install -y libportaudio0 libportaudio2 libportaudiocpp0  \
     apt-transport-https pulseaudio
     echo_green "Installing system packages...[OK]"

--- a/install/rpi_kalliope_install.yml
+++ b/install/rpi_kalliope_install.yml
@@ -50,7 +50,6 @@
         - libssl-dev
         - portaudio19-dev
         - build-essential
-        - sox
         - libatlas3-base
         - mplayer
         - libyaml-dev

--- a/kalliope/tts/pico2wave/pico2wave.py
+++ b/kalliope/tts/pico2wave/pico2wave.py
@@ -2,7 +2,6 @@ import os
 import subprocess
 
 from kalliope.core.TTS.TTSModule import TTSModule, MissingTTSParameter
-import sox
 
 import logging
 import sys
@@ -15,7 +14,6 @@ class Pico2wave(TTSModule):
 
     def __init__(self, **kwargs):
         super(Pico2wave, self).__init__(**kwargs)
-        self.samplerate = kwargs.get('samplerate', None)
         self.path = kwargs.get('path', None)
 
         self._check_parameters()
@@ -65,14 +63,7 @@ class Pico2wave(TTSModule):
 
         # generate the file with pico2wav
         subprocess.call(final_command)
-        
-        # convert samplerate
-        if self.samplerate is not None:
-            tfm = sox.Transformer()
-            tfm.rate(samplerate=self.samplerate)
-            tfm.build(str(tmp_path), str(tmp_path) + "tmp_name.wav")
-            os.rename(str(tmp_path) + "tmp_name.wav", tmp_path)
-        
+
         # remove the extension .wav
         os.rename(tmp_path, self.file_path)
 

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,6 @@ setup(
         'sounddevice>=0.3.13',
         'SoundFile>=0.10.2',
         'pyalsaaudio>=0.8.4',
-        'sox>=1.3.7',
         'paho-mqtt>=1.4.0',
         'voicerss_tts>=1.0.6',
         'gTTS>=2.0.3',


### PR DESCRIPTION
In order to close [#620](https://github.com/kalliope-project/kalliope/issues/620) and [#619](https://github.com/kalliope-project/kalliope/pull/619).

Sox was used to convert the samplerate of pico2wav, because not all usb mics support 16 Khz. With pulseaudio this is not a problem anymore. 
