### PR TITLE
Hotfix 0.7.0

### DIFF
--- a/docs/settings/triggers/snowboy.md
+++ b/docs/settings/triggers/snowboy.md
@@ -101,7 +101,7 @@ Then, open an issue or create a pull request to add the model to the list bellow
 ## Pretrained universal models
 
 Snowboy provides pretrained universal models.
-Ŷou can either find them [here](https://github.com/Kitt-AI/snowboy/tree/master/resources)
+You can find them [here](https://github.com/Kitt-AI/snowboy/tree/master/resources).
 
 Here is the list of the umdl models, and the parameters that you have to use for them:
 

--- a/kalliope/signals/order/order.py
+++ b/kalliope/signals/order/order.py
@@ -110,7 +110,6 @@ class Order(SignalModule, Thread):
         self.trigger_instance.unpause()  
         self.trigger_callback_called = False    
         self.next_state()
-        #self.waiting_for_trigger_callback_thread()
 
     def waiting_for_trigger_callback_thread(self):
         """
@@ -125,8 +124,6 @@ class Order(SignalModule, Thread):
         # this loop is used to keep the main thread alive
         while not self.trigger_callback_called:
             sleep(0.1)
-        # if here, then the trigger has been called
-        HookManager.on_triggered()
         self.next_state()
 
     def waiting_for_order_listener_callback_thread(self):
@@ -155,6 +152,8 @@ class Order(SignalModule, Thread):
         """
         logger.debug("[Order] Entering state: %s" % self.state)
         self.trigger_instance.pause()
+        # if here, then the trigger has been called and paused
+        HookManager.on_triggered()
         self.next_state()
 
     def start_order_listener_thread(self):

--- a/kalliope/stt/SpeechRecognizer.py
+++ b/kalliope/stt/SpeechRecognizer.py
@@ -256,9 +256,6 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
         # The maximum time it will continue to record silence
         # when not enough noise has been detected
         self.recording_timeout_with_silence = recording_timeout_with_silence
-        if not os.path.exists("/tmp/kalliope/"):
-            os.makedirs("/tmp/kalliope/")
-        self.mic_level_file = "/tmp/kalliope/mic_level"
 
     def record_sound_chunk(self, source):
         return source.stream.read(source.CHUNK, self.overflow_exc)
@@ -315,21 +312,9 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
             # The phrase is complete if the noise_tracker end of sentence
             # criteria is met or if the  top-button is pressed
             phrase_complete = (noise_tracker.recording_complete())
-
-            # Periodically write the energy level to the mic level file.
-            if num_chunks % 10 == 0:
-                self.write_mic_level(energy, source)
-
+            
         return byte_data
     
-    def write_mic_level(self, energy, source):
-        with open(self.mic_level_file, 'w') as f:
-            f.write('Energy:  cur={} thresh={:.3f}'.format(
-                energy,
-                self.energy_threshold
-                )
-            )
-
     @staticmethod
     def _create_audio_data(raw_data, source):
         """


### PR DESCRIPTION
The on_triggered hook get called while the trigger is still active, this can result in a false positiv trigger activation right after a order got executed because the chunks of the trigger are in a queue and get process after unpausing the trigger. 
This hotfix makes sure the trigger get paused before the on_trigger hook get called. 

Also we don't need to write the microphone level to a file, this has got no use for us.  