### PR TITLE
Update gevent

### DIFF
--- a/install/files/python_requirements.txt
+++ b/install/files/python_requirements.txt
@@ -27,4 +27,4 @@ paho-mqtt>=1.4.0
 voicerss_tts>=1.0.6
 gTTS>=2.0.3
 urllib3>=1.25.3
-gevent==1.4.0
+gevent>=20.9.0

--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,7 @@ setup(
         'voicerss_tts>=1.0.6',
         'gTTS>=2.0.3',
         'urllib3>=1.25.3',
-        'gevent==1.4.0'
+        'gevent>=20.9.0'
     ],
 
     # additional files


### PR DESCRIPTION
Update gevent to 20.9.0 in order to fix segmentation fault when using the API and errors on Kalliope start