### PR TITLE
Added cache to Utils.get_dynamic_class_instantiation() 

### DIFF
--- a/Tests/test_utils.py
+++ b/Tests/test_utils.py
@@ -132,12 +132,18 @@ class TestUtils(unittest.TestCase):
         sl.settings.resource_dir = '/var/tmp/test/resources'
 
         neuron = Neuron(name='Say', parameters={'message': 'test dynamic class instantiate'})
-        self.assertTrue(isinstance(Utils.get_dynamic_class_instantiation(package_name="neurons",
-                                                                         module_name=neuron.name.capitalize(),
-                                                                         parameters=neuron.parameters,
-                                                                         resources_dir='/var/tmp/test/resources'),
-                                   Say),
-                        "Fail instantiate a class")
+        say1 = Utils.get_dynamic_class_instantiation(package_name="neurons",
+                                                     module_name=neuron.name.capitalize(),
+                                                     parameters=neuron.parameters,
+                                                     resources_dir='/var/tmp/test/resources')
+        self.assertTrue(isinstance(say1, Say), "Failed to dynamically instantiate neuron 'Say'")
+        say2 = Utils.get_dynamic_class_instantiation(package_name="neurons",
+                                                     module_name=neuron.name.capitalize(),
+                                                     parameters=neuron.parameters,
+                                                     resources_dir='/var/tmp/test/resources')
+        self.assertTrue(isinstance(say2, Say), "Failed to dynamically instantiate neuron 'Say'")
+        self.assertNotEqual(id(say1), id(say2),
+                            "Dynamic class instantiations must return unique instances")
 
     def test_is_containing_bracket(self):
         #  Success


### PR DESCRIPTION
This implements a caching mechanism to Utils.get_dynamic_class_instantiation() by storing a reference to the to-be-instantiad class in a directory in Utils.klass_cache with the package_path as the key. This should be a side-effect free change that optimizes runtime for class instantiations where those classes maintain state in class attributes.

My specific use case is the vosk STT plugin, which (now) stores its (~50MB) model in a class attribute in order to reduce class instantiation time for each STT pass (juergenpabel/kalliope-vosk@6d63709). Only the first instantation takes about 1-2 secs on a pi4, subsequent instantiations are now instantanious.