### PR TITLE
InvalidParameterException: self.message not set

### DIFF
--- a/kalliope/core/NeuronModule.py
+++ b/kalliope/core/NeuronModule.py
@@ -27,6 +27,7 @@ class InvalidParameterException(NeuronExceptions):
     def __init__(self, message):
         # Call the base class constructor with the parameters it needs
         super(InvalidParameterException, self).__init__(message)
+        self.message = message
 
 
 class MissingParameterException(NeuronExceptions):


### PR DESCRIPTION
Stumbled upon this error, quick bugfix (don't remember where it occured, but some kalliope exception handling code expected an instance variable 'message' for any NeuronExceptions). It would probably be more reasonable to put self.message assignment in NeuronExceptions, but this is the most non-invasive fix.