### PR TITLE
Players are now installable modules

### DIFF
--- a/Tests/test_models.py
+++ b/Tests/test_models.py
@@ -203,7 +203,8 @@ class TestModels(unittest.TestCase):
             'neuron_folder': '/path/neuron',
             'stt_folder': '/path/stt',
             'trigger_folder': '/path/trigger',
-            'signal_folder': None
+            'signal_folder': None,
+            'player_folder': None
         }
 
         self.assertDictEqual(expected_result_serialize, resource1.serialize())
@@ -300,7 +301,7 @@ class TestModels(unittest.TestCase):
                                 send_anonymous_usage_stats=0)
             setting3.kalliope_version = "0.4.5"
 
-            expected_result_serialize = {'default_tts_name': 'pico2wav', 'default_stt_name': 'google', 'default_trigger_name': 'swoyboy', 'default_player_name': 'mplayer', 'ttss': [{'name': 'tts1', 'parameters': {}}], 'stts': [{'name': 'stt1', 'parameters': {}}], 'triggers': [{'name': 'snowboy', 'parameters': {}}], 'players': [{'name': 'player1', 'parameters': None}], 'rest_api': {'password_protected': True, 'login': 'admin', 'password': 'password', 'active': True, 'port': 5000, 'allowed_cors_origin': '*'}, 'cache_path': '/tmp/kalliope', 'resources': {'neuron_folder': None, 'stt_folder': None, 'tts_folder': None, 'trigger_folder': None, 'signal_folder': None}, 'variables': {'key1': 'val1'}, 'machine': 'pumpkins', 'kalliope_version': '0.4.5', 'options': {'name': 'Options', 'recognizer_multiplier': 1.0, 'recognizer_energy_ratio': 1.5, 'recognizer_recording_timeout': 15.0, 'recognizer_recording_timeout_with_silence': 3.0, 'deaf': None, 'mute': None}, 'hooks': None, 'send_anonymous_usage_stats': 0}
+            expected_result_serialize = {'default_tts_name': 'pico2wav', 'default_stt_name': 'google', 'default_trigger_name': 'swoyboy', 'default_player_name': 'mplayer', 'ttss': [{'name': 'tts1', 'parameters': {}}], 'stts': [{'name': 'stt1', 'parameters': {}}], 'triggers': [{'name': 'snowboy', 'parameters': {}}], 'players': [{'name': 'player1', 'parameters': None}], 'rest_api': {'password_protected': True, 'login': 'admin', 'password': 'password', 'active': True, 'port': 5000, 'allowed_cors_origin': '*'}, 'cache_path': '/tmp/kalliope', 'resources': {'neuron_folder': None, 'stt_folder': None, 'tts_folder': None, 'trigger_folder': None, 'signal_folder': None, 'player_folder': None}, 'variables': {'key1': 'val1'}, 'machine': 'pumpkins', 'kalliope_version': '0.4.5', 'options': {'name': 'Options', 'recognizer_multiplier': 1.0, 'recognizer_energy_ratio': 1.5, 'recognizer_recording_timeout': 15.0, 'recognizer_recording_timeout_with_silence': 3.0, 'deaf': None, 'mute': None}, 'hooks': None, 'send_anonymous_usage_stats': 0}
 
             self.maxDiff = None
             self.assertDictEqual(expected_result_serialize, setting1.serialize())

--- a/Tests/test_player_launcher.py
+++ b/Tests/test_player_launcher.py
@@ -31,7 +31,8 @@ class TestPlayerLauncher(unittest.TestCase):
 
             mock_get_class_instantiation.assert_called_once_with(package_name="players",
                                                                  module_name=player1.name,
-                                                                 parameters=player1.parameters)
+                                                                 parameters=player1.parameters,
+                                                                 resources_dir=None)
             mock_get_class_instantiation.reset_mock()
 
             # Get the player 2
@@ -40,5 +41,6 @@ class TestPlayerLauncher(unittest.TestCase):
 
             mock_get_class_instantiation.assert_called_once_with(package_name="players",
                                                                  module_name=player2.name,
-                                                                 parameters=player2.parameters)
+                                                                 parameters=player2.parameters,
+                                                                 resources_dir=None)
             mock_get_class_instantiation.reset_mock()

--- a/kalliope/__init__.py
+++ b/kalliope/__init__.py
@@ -62,6 +62,7 @@ def parse_args(args):
     parser.add_argument("--tts-name", help="TTS name to uninstall")
     parser.add_argument("--trigger-name", help="Trigger name to uninstall")
     parser.add_argument("--signal-name", help="Signal name to uninstall")
+    parser.add_argument("--player-name", help="Player name to uninstall")
     parser.add_argument("--deaf", action='store_true', help="Starts Kalliope deaf")
     parser.add_argument('-v', '--version', action='version',
                         version='Kalliope ' + version_str)
@@ -115,13 +116,15 @@ def main():
                 and not parser.stt_name \
                 and not parser.tts_name \
                 and not parser.trigger_name \
-                and not parser.signal_name:
+                and not parser.signal_name \
+                and not parser.player_name:
             Utils.print_danger("You must specify a module name with "
                                "--neuron-name "
                                "or --stt-name "
                                "or --tts-name "
                                "or --trigger-name "
-                               "or --signal-name")
+                               "or --signal-name "
+                               "or --player-name")
             sys.exit(1)
         else:
             res_manager = ResourcesManager()
@@ -129,7 +132,8 @@ def main():
                                   stt_name=parser.stt_name,
                                   tts_name=parser.tts_name,
                                   trigger_name=parser.trigger_name,
-                                  signal_name=parser.signal_name)
+                                  signal_name=parser.signal_name,
+                                  player_name=parser.player_name)
         return
 
     # load the brain once

--- a/kalliope/core/ConfigurationManager/DnaLoader.py
+++ b/kalliope/core/ConfigurationManager/DnaLoader.py
@@ -9,7 +9,7 @@ class InvalidDNAException(Exception):
     pass
 
 
-VALID_DNA_MODULE_TYPE = ["neuron", "stt", "tts", "trigger", "signal"]
+VALID_DNA_MODULE_TYPE = ["neuron", "stt", "tts", "trigger", "signal", "player"]
 
 
 class DnaLoader(object):

--- a/kalliope/core/ConfigurationManager/SettingLoader.py
+++ b/kalliope/core/ConfigurationManager/SettingLoader.py
@@ -568,14 +568,23 @@ class SettingLoader(with_metaclass(Singleton, object)):
                 else:
                     raise SettingInvalidException("The path %s does not exist on the system" % signal_folder)
 
+            if "player" in resource_dir:
+                player_folder = resource_dir["player"]
+                if os.path.exists(player_folder):
+                    logger.debug("[SettingLoader] Player resource folder path loaded: %s" % player_folder)
+                    resource_object.player_folder = player_folder
+                else:
+                    raise SettingInvalidException("The path %s does not exist on the system" % player_folder)
+
             if neuron_folder is None \
                     and stt_folder is None \
                     and tts_folder is None \
                     and trigger_folder is None \
-                    and signal_folder is None:
+                    and signal_folder is None \
+                    and player_folder is None:
                 raise SettingInvalidException("No required folder has been provided in the setting resource_directory. "
                                               "Define : \'neuron\' or/and \'stt\' or/and \'tts\' or/and \'trigger\' "
-                                              "or/and \'signal\'")
+                                              "or/and \'signal\' or/and \'player\'")
 
         except KeyError:
             logger.debug("Resource directory not found in settings")

--- a/kalliope/core/Models/settings/Resources.py
+++ b/kalliope/core/Models/settings/Resources.py
@@ -5,13 +5,14 @@ class Resources(SettingsEntry):
     """
 
     """
-    def __init__(self, neuron_folder=None, stt_folder=None, tts_folder=None, trigger_folder=None, signal_folder=None):
+    def __init__(self, neuron_folder=None, stt_folder=None, tts_folder=None, trigger_folder=None, signal_folder=None, player_folder=None):
         super(Resources, self).__init__("Resources")
         self.neuron_folder = neuron_folder
         self.stt_folder = stt_folder
         self.tts_folder = tts_folder
         self.trigger_folder = trigger_folder
         self.signal_folder = signal_folder
+        self.player_folder = player_folder
 
     def __str__(self):
         return str(self.serialize())
@@ -29,7 +30,8 @@ class Resources(SettingsEntry):
             'stt_folder': self.stt_folder,
             'tts_folder': self.tts_folder,
             'trigger_folder': self.trigger_folder,
-            'signal_folder': self.signal_folder
+            'signal_folder': self.signal_folder,
+            'player_folder': self.player_folder
         }
 
     def __eq__(self, other):

--- a/kalliope/core/PlayerLauncher.py
+++ b/kalliope/core/PlayerLauncher.py
@@ -19,12 +19,18 @@ class PlayerLauncher(object):
         :return: the Player instance
         :rtype: Player
         """
+
+        player_folder = None
+        if settings.resources:
+            player_folder = settings.resources.player_folder
+
         player_instance = None
         for player in settings.players:
             if player.name == settings.default_player_name:
                 logger.debug("PlayerLauncher: Start player %s with parameters: %s" % (player.name, player.parameters))
                 player_instance = Utils.get_dynamic_class_instantiation(package_name="players",
                                                                         module_name=player.name,
-                                                                        parameters=player.parameters)
+                                                                        parameters=player.parameters,
+                                                                        resources_dir=player_folder)
                 break
         return player_instance

--- a/kalliope/core/ResourcesManager.py
+++ b/kalliope/core/ResourcesManager.py
@@ -33,6 +33,7 @@ TYPE_TTS = "tts"
 TYPE_STT = "stt"
 TYPE_TRIGGER = "trigger"
 TYPE_SIGNAL = "signal"
+TYPE_PLAYER = "player"
 
 
 class ResourcesManagerException(Exception):
@@ -129,7 +130,8 @@ class ResourcesManager(object):
                   tts_name=None,
                   stt_name=None,
                   trigger_name=None,
-                  signal_name=None):
+                  signal_name=None,
+                  player_name=None):
         """
         Uninstall a community resource
         """
@@ -156,6 +158,11 @@ class ResourcesManager(object):
             target_path_to_delete = self._get_target_folder(resources=self.settings.resources,
                                                             module_type=TYPE_SIGNAL)
             module_name = signal_name
+
+        if player_name is not None:
+            target_path_to_delete = self._get_target_folder(resources=self.settings.resources,
+                                                            module_type=TYPE_PLAYER)
+            module_name = player_name
 
         if target_path_to_delete is not None:
             try:
@@ -249,7 +256,8 @@ class ResourcesManager(object):
                 TYPE_STT: resources.stt_folder,
                 TYPE_TTS: resources.tts_folder,
                 TYPE_TRIGGER: resources.trigger_folder,
-                TYPE_SIGNAL: resources.signal_folder
+                TYPE_SIGNAL: resources.signal_folder,
+                TYPE_PLAYER: resources.player_folder
             }
         except AttributeError:
             # will be raised if the resource folder is not set in settings


### PR DESCRIPTION
Added support for a new module type "player". Players can now be installed like so:

`kalliope install --git-url https://github.com/juergenpabel/kalliope_player_mute.git`

(My "mute" player does nothing - not even open a sound device)